### PR TITLE
Add 'MSI Modern 15 A11M' to tested_devices.md

### DIFF
--- a/docs/tested_devices.md
+++ b/docs/tested_devices.md
@@ -6,5 +6,6 @@
 | MSI Summit E16 Flip A12UCT    | E1592IMS.10C 08/19/2022 | ✔ Mode<br> ✔ Battery Limit<br> ✔ Cooler Boost | ✔ Keyboard Backlit<br> ✔ FN -> Super<br> ❌ Webcam<br> ✔ USB Power Share |
 | MSI GS75 Stealth 8SE          | 17G1EMS1.107 07/12/2019 | ❌ Mode<br> ✔ Battery Limit<br> ✔ Cooler Boost | ❌ Keyboard Backlit<br> ❌ FN -> Super<br> ❌ Webcam<br> ❌ USB Power Share |
 | MSI Stealth 15M A11SEK        | 1562EMS1.115 06/25/2021 | ❓ Mode<br> ✔ Battery Limit<br> ✔ Cooler Boost | ❌ Keyboard Backlit<br> ✔ FN -> Super<br> ❓ Webcam<br> ❓ USB Power Share |
+| MSI Modern 15 A11M    | 1552EMS1.118 07/21/2021 | ✔ Mode<br> ✔ Battery Limit<br> ✔ Cooler Boost | ✔ Keyboard Backlit<br> ✔ FN -> Super<br> ✔ Webcam<br>  ❌ USB Power Share |
 
 If the table does not contain the device you are using, then you can add it.


### PR DESCRIPTION
I can confirm that this app works correctly on the MSI Modern 15 A11M.

A few things to note:
* USB Power Share is grayed out (MSI Center Pro does not mention this feature, so this model probably doesn't have it)
* 'Auto turn off in 10 sec' keyboard backlight mode has no effect

EC dump for reference
```
00000000  00 80 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000010  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000020  00 00 00 00 00 00 00 00  0a 05 00 80 08 04 09 0b  |................|
00000030  02 05 00 05 08 00 50 81  f4 0c 88 2c 4b 01 c0 00  |......P....,K...|
00000040  16 0d 43 00 e3 0c 74 fd  9e 08 cc 2d d5 0b fa 32  |..C...t....-...2|
00000050  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000060  00 00 00 00 00 00 00 00  2a 00 41 46 4d 50 53 58  |........*.AFMPSX|
00000070  64 00 00 23 23 41 41 50  64 46 03 05 05 05 05 03  |d..##AAPdF......|
00000080  00 00 41 46 4d 50 53 58  64 00 00 23 23 3c 3c 4b  |..AFMPSXd..##<<K|
00000090  64 46 03 05 05 06 03 03  02 00 6e 02 00 66 00 00  |dF........n..f..|
000000a0  31 35 35 32 45 4d 53 31  2e 31 31 38 30 37 32 31  |1552EMS1.1180721|
000000b0  32 30 32 31 30 38 3a 35  31 3a 35 39 00 00 00 00  |202108:51:59....|
000000c0  00 00 01 35 00 00 00 00  00 00 00 00 00 00 00 00  |...5............|
000000d0  00 00 c2 81 1d 00 05 e4  00 03 00 00 00 00 00 00  |................|
000000e0  e2 00 00 e3 0c 00 00 00  00 00 00 8f 00 84 00 e4  |................|
000000f0  08 00 7f 80 8c 3c 32 00  3c 32 00 00 00 00 00 00  |.....<2.<2......|
00000100

```