### PR TITLE
Add mcontrolcenter-bin PKGBUILD 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 *.exe
 *.out
 *.app
+
+# AUR packaging leftovers
+scripts/aur-bin-pkgbuild/*.tar*

--- a/scripts/aur-bin-pkgbuild/PKGBUILD
+++ b/scripts/aur-bin-pkgbuild/PKGBUILD
@@ -25,5 +25,5 @@ package() {
   install -Dm644 "${app_directory}/mcontrolcenter.svg" "${pkgdir}/usr/share/icons/hicolor/scalable/apps/mcontrolcenter.svg"
   install -Dm755 "${app_directory}/mcontrolcenter-helper" "${pkgdir}/usr/libexec/mcontrolcenter-helper"
   install -Dm644 "${app_directory}/mcontrolcenter-helper.conf" "${pkgdir}/usr/share/dbus-1/system.d/mcontrolcenter-helper.conf"
-  install -Dm644 "${app_directory}/mcontrolcenter.helper.service" "${pkgdir}/usr/share/dbus-1/system-services/mcontrolcenter-helper.service"
+  install -Dm644 "${app_directory}/mcontrolcenter.helper.service" "${pkgdir}/usr/share/dbus-1/system-services/mcontrolcenter.helper.service"
 }

--- a/scripts/aur-bin-pkgbuild/PKGBUILD
+++ b/scripts/aur-bin-pkgbuild/PKGBUILD
@@ -1,0 +1,29 @@
+# Maintainer: X
+# Contributor: JordanViknar
+pkgname=mcontrolcenter-bin
+pkgver=0.2.0
+pkgrel=1
+pkgdesc="An application that allows you to change the settings of MSI laptops running Linux."
+arch=('x86_64')
+url="https://github.com/dmitry-s93/MControlCenter"
+license=('GPL3')
+depends=(
+  'qt5-base'
+)
+conflicts=('mcontrolcenter')
+provides=('mcontrolcenter')
+
+source=("https://github.com/dmitry-s93/MControlCenter/releases/download/${pkgver}/MControlCenter-${pkgver}.tar.gz")
+
+sha256sums=('9382ee44404db5297b44c8c41ef14b65a550cd46d52811f0c654c5954428f835')
+
+package() {
+  app_directory="${srcdir}/MControlCenter-${pkgver}/app"
+
+  install -Dm755 "${app_directory}/mcontrolcenter" "${pkgdir}/usr/bin/mcontrolcenter"
+  install -Dm644 "${app_directory}/mcontrolcenter.desktop" "${pkgdir}/usr/share/applications/mcontrolcenter.desktop"
+  install -Dm644 "${app_directory}/mcontrolcenter.svg" "${pkgdir}/usr/share/icons/hicolor/scalable/apps/mcontrolcenter.svg"
+  install -Dm755 "${app_directory}/mcontrolcenter-helper" "${pkgdir}/usr/libexec/mcontrolcenter-helper"
+  install -Dm644 "${app_directory}/mcontrolcenter-helper.conf" "${pkgdir}/usr/share/dbus-1/system.d/mcontrolcenter-helper.conf"
+  install -Dm644 "${app_directory}/mcontrolcenter.helper.service" "${pkgdir}/usr/share/dbus-1/system-services/mcontrolcenter-helper.service"
+}

--- a/scripts/aur-bin-pkgbuild/PKGBUILD
+++ b/scripts/aur-bin-pkgbuild/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: X
 # Contributor: JordanViknar
 pkgname=mcontrolcenter-bin
-pkgver=0.3.1
+pkgver=0.3.2
 pkgrel=1
 pkgdesc="An application that allows you to change the settings of MSI laptops running Linux."
 arch=('x86_64')
@@ -15,7 +15,7 @@ provides=('mcontrolcenter')
 
 source=("https://github.com/dmitry-s93/MControlCenter/releases/download/${pkgver}/MControlCenter-${pkgver}.tar.gz")
 
-sha256sums=('085a03fde36ed7bb0ee1424ba3e1f223c1f6bef1d913d4c85c0bdc85171b3308')
+sha256sums=('bab563f692fb3d42494d95de21611d230e0b0736e2e80f08cf8a1b7b990d9f0f')
 
 package() {
   app_directory="${srcdir}/MControlCenter-${pkgver}/app"

--- a/scripts/aur-bin-pkgbuild/PKGBUILD
+++ b/scripts/aur-bin-pkgbuild/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: X
 # Contributor: JordanViknar
 pkgname=mcontrolcenter-bin
-pkgver=0.3.0
+pkgver=0.3.1
 pkgrel=1
 pkgdesc="An application that allows you to change the settings of MSI laptops running Linux."
 arch=('x86_64')
@@ -15,7 +15,7 @@ provides=('mcontrolcenter')
 
 source=("https://github.com/dmitry-s93/MControlCenter/releases/download/${pkgver}/MControlCenter-${pkgver}.tar.gz")
 
-sha256sums=('ca36047b55fab61d885226aa85900a385b7fc6fb11799e7390dbc9ac78e64490')
+sha256sums=('085a03fde36ed7bb0ee1424ba3e1f223c1f6bef1d913d4c85c0bdc85171b3308')
 
 package() {
   app_directory="${srcdir}/MControlCenter-${pkgver}/app"

--- a/scripts/aur-bin-pkgbuild/PKGBUILD
+++ b/scripts/aur-bin-pkgbuild/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: X
 # Contributor: JordanViknar
 pkgname=mcontrolcenter-bin
-pkgver=0.2.0
+pkgver=0.3.0
 pkgrel=1
 pkgdesc="An application that allows you to change the settings of MSI laptops running Linux."
 arch=('x86_64')
@@ -15,7 +15,7 @@ provides=('mcontrolcenter')
 
 source=("https://github.com/dmitry-s93/MControlCenter/releases/download/${pkgver}/MControlCenter-${pkgver}.tar.gz")
 
-sha256sums=('9382ee44404db5297b44c8c41ef14b65a550cd46d52811f0c654c5954428f835')
+sha256sums=('ca36047b55fab61d885226aa85900a385b7fc6fb11799e7390dbc9ac78e64490')
 
 package() {
   app_directory="${srcdir}/MControlCenter-${pkgver}/app"


### PR DESCRIPTION
Hello. Thank you for this project, I was waiting for quite a long time to see someone make a control center application for MSI laptops like mine. (By the way, your application only supports it partially, it's an MSI GE63 RAIDER RGB 8RE, I'll have to remember to make an issue about it.)

I personally use Arch Linux, and I wasn't really satisfied with the idea of using an installation script when we have the entire Arch Build System available.
As such, in order for Arch(-based) users to easily download your application, I've made a PKGBUILD file that, when ran with `makepkg` (I personally prefer `makepkg -sirc`), will download the 0.2.0 release of MControlCenter and set up a package from it.
Since I am directly using binaries, the name of the package is **mcontrolcenter-bin**, in order to respect the [AUR submission guidelines](https://wiki.archlinux.org/title/AUR_submission_guidelines).

***Unfortunately***, I will not have the time to maintain this package on the AUR, thus why I am instead inserting it in a pull request. The idea is that the PKGBUILD stays on the repository until someone is available to maintain it on the AUR.

Finally, since this is my first time making a PKGBUILD, **I'd highly recommend you test it yourself** (using the live image of an Arch-based distribution for example). I've made sure to follow as closely as possible the installation script you provided, and the resulting package does seem to be working, but it's possible I've missed some quirks, dependencies, etc. **DO NOT MERGE** until either you or someone else also confirms the program works properly when installed like this.