### PR TITLE
Added 'MSI Modern 15 A11SB' to tested_devices.md

### DIFF
--- a/docs/tested_devices.md
+++ b/docs/tested_devices.md
@@ -7,6 +7,7 @@
 | MSI GS75 Stealth 8SE          | 17G1EMS1.107 07/12/2019 | ❌ Mode<br> ✔ Battery Limit<br> ✔ Cooler Boost | ❌ Keyboard Backlit<br> ❌ FN -> Super<br> ❌ Webcam<br> ❌ USB Power Share                                                       |
 | MSI Stealth 15M A11SEK        | 1562EMS1.115 06/25/2021 | ❓ Mode<br> ✔ Battery Limit<br> ✔ Cooler Boost | ❌ Keyboard Backlit<br> ✔ FN -> Super<br> ❓ Webcam<br> ❓ USB Power Share                                                       |
 | MSI Modern 15 A11M            | 1552EMS1.118 07/21/2021 | ✔ Mode<br> ✔ Battery Limit<br> ✔ Cooler Boost | ✔ Keyboard Backlit (auto turn off not working)<br> ✔ FN -> Super<br> ✔ Webcam<br>  ❌ USB Power Share                          |
+| MSI Modern 15 A11SB           | 1552EMS1.120 01/11/2022 | ✔ Mode<br> ✔ Battery Limit<br> ✔ Cooler Boost | ✔ Keyboard Backlit (auto turn off not working)<br> ❌ FN -> Super (greyed out)<br> ✔ Webcam<br>  ❌ USB Power Share (greyed out) |
 | MSI Prestige 14 Evo           | 14C4EMS1.120 04/25/2022 | ✔ Mode<br> ✔ Battery Limit<br> ✔ Cooler Boost | ✔ Keyboard Backlit (auto turn off not working)<br> ✔ FN -> Super<br> ❌ Webcam (greyed out)<br> ❌ USB Power Share (greyed out) |
 
 If the table does not contain the device you are using, then you can add it.


### PR DESCRIPTION
Tested on Pop!_OS 22.04.

Seems to work just as well as MSI Center Pro on Windows 10/11, except for the 'FN -> Super' feature which is greyed out in MControlCenter.