### PR TITLE
Add Nix package definition

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -28,6 +28,8 @@ stdenv.mkDerivation (finalAttrs: rec {
 
   src = ./.;
 
+  patches = [ ./nixos.patch ];
+
   cmakeFlags = [
     "-DENABLE_TESTING=OFF"
     "-DENABLE_INSTALL=ON"

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,57 @@
+{ pkgs, lib, stdenv, qtbase, wrapQtAppsHook, qttools, makeDesktopItem, copyDesktopItems }:
+
+stdenv.mkDerivation (finalAttrs: rec {
+  pname = "MControlCenter";
+  version = "0.4.1";
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "MControlCenter";
+      exec = "mcontrolcenter";
+      icon = "mcontrolcenter";
+      comment = finalAttrs.meta.description;
+      desktopName = "MControlCenter";
+      categories = [ "System" ];
+    })
+  ];
+
+  buildInputs = [
+    pkgs.cmake
+    qtbase
+  ];
+
+  nativeBuildInputs = [
+    wrapQtAppsHook
+    qttools
+    copyDesktopItems
+  ];
+
+  src = ./.;
+
+  cmakeFlags = [
+    "-DENABLE_TESTING=OFF"
+    "-DENABLE_INSTALL=ON"
+  ];
+
+  installPhase = ''
+    	install -Dm755 mcontrolcenter $out/bin/mcontrolcenter
+    	install -Dm755 helper/mcontrolcenter-helper $out/libexec/mcontrolcenter-helper
+    	install -Dm644  $src/resources/mcontrolcenter.svg $out/share/icons/hicolor/32x32/apps/mcontrolcenter.svg
+    	install -Dm644 $src/src/helper/mcontrolcenter-helper.conf $out/share/dbus-1/system.d/mcontrolcenter-helper.conf
+      mkdir -p $out/share/dbus-1/system-services
+      echo "[D-BUS Service]" >> $out/share/dbus-1/system-services/mcontrolcenter.helper.service
+      echo "Name=mcontrolcenter.helper" >> $out/share/dbus-1/system-services/mcontrolcenter.helper.service
+      echo "Exec=$out/libexec/mcontrolcenter-helper" >> $out/share/dbus-1/system-services/mcontrolcenter.helper.service
+      echo "User=root" >> $out/share/dbus-1/system-services/mcontrolcenter.helper.service
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/dmitry-s93/MControlCenter";
+    description = ''
+      An application that allows you to change the settings of MSI laptops running Linux.";
+    '';
+    licencse = licenses.gpl3;
+    platforms = with platforms; linux;
+    # maintainers = [ maintainers.nadimkobeissi ];    
+  };
+})

--- a/nixos.patch
+++ b/nixos.patch
@@ -1,0 +1,13 @@
+diff --git a/src/helper/helper.cpp b/src/helper/helper.cpp
+index 5c291c8..382c18f 100644
+--- a/src/helper/helper.cpp
++++ b/src/helper/helper.cpp
+@@ -57,7 +57,7 @@ bool Helper::isEcSysModuleLoaded() const {
+ bool Helper::loadEcSysModule() const {
+     fprintf(stderr, "%s\n", qPrintable("Trying to load the ec_sys kernel module"));
+     auto *process = new QProcess();
+-    process->start("sh", QStringList() << "-c" << "/usr/sbin/modprobe ec_sys write_support=1 2>&1");
++    process->start("sh", QStringList() << "-c" << "/run/current-system/sw/bin/modprobe ec_sys write_support=1 2>&1");
+     process->waitForFinished(1000);
+     if (QByteArray output = process->readAllStandardOutput(); output != "")
+         fprintf(stderr, "%s", qPrintable(output));


### PR DESCRIPTION
This Nix package definition allows MControlCenter to be used under NixOS. The NixOS package will automatically apply a patch correcting the path to `modprobe`, allowing the `ec_sys` kernel module to be automatically loaded with `write_support=1` under NixOS.