### PR TITLE
fix(build): remove invalid cmake command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,8 +84,4 @@ install(TARGETS mcontrolcenter
     BUNDLE DESTINATION .
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-if(QT_VERSION_MAJOR EQUAL 6)
-    qt_finalize_executable(MControlCenter)
-endif()
-
 add_subdirectory(src/helper ${CMAKE_BINARY_DIR}/helper)


### PR DESCRIPTION
Removed invalid cmake command that caused the cmake build to fail when building with qt6 
This change should fix issues #120 and #152

Tested on: KDE with Plasma 6 
Qt version: 6.7.0