### PR TITLE
Fixed high fan speed displayed on low RPM

### DIFF
--- a/src/operate.cpp
+++ b/src/operate.cpp
@@ -162,14 +162,20 @@ int Operate::getGpuTemp() const {
 }
 
 int Operate::getFan1Speed() const {
-    int value = helper.getValue(fan1Address);
+    // Read 2 bytes (big-endian)
+    int value0 = helper.getValue(fan1Address);
+    int value1 = helper.getValue(fan1Address - 1);
+    int value = (value1 << 8) | value0;
     if (value > 0)
         return 470000 / value;
     return value;
 }
 
 int Operate::getFan2Speed() const {
-    int value = helper.getValue(fan2Address);
+    // Read 2 bytes (big-endian)
+    int value0 = helper.getValue(fan2Address);
+    int value1 = helper.getValue(fan2Address - 1);
+    int value = (value1 << 8) | value0;
     if (value > 0)
         return 470000 / value;
     return value;


### PR DESCRIPTION
## Configuration
Computer: MSI Bravo 15 A4DDR
Motherboard: 16WKEMS1.105
GPU Fan address: 0xCA and 0xCB (in green, fan 2)
CPU Fan address: 0xCC and 0xCD (in cyan/blue, fan 1)
This is the same address as described in [isw msi-ec datasheet](https://github.com/YoyPa/isw/blob/master/wiki/msi%20ec.png)

## The issue
With my configuration, the fan speed is represented by 2 bytes as described above.
MControlCenter only reads the second byte.
In general, this is fine, since the first byte has the value 0x00 (e.g. CPU RPM in cyan is correct)

But my GPU fan is often in a low RPM (e.g. transition between on and off).
Which means it is possible to have the value `0x0115`, where the RPM should be `1696`,
while MControlCenter calculates `470000/0x15 = 22k` RPM ! (different from the picture below because the value changes quickly).

The value was `0x0123` when MControlCenter read, RPM should be 1696.
![rpm_GPU_inf](https://github.com/dmitry-s93/MControlCenter/assets/30299784/cf7ca721-dbf9-4d7a-b255-95faf109fc2b)
The value was `0x0101` when MControlCenter read, RPM should be 1828.
![rpm_GPU_inf5](https://github.com/dmitry-s93/MControlCenter/assets/30299784/da42db3f-74c7-4192-8e5d-3a7129f35e3c)
When the value is `0x00ff`, the RPM displayed is ~1843 as expected.

## Fix
Read the 2 bytes and combine them `value = (value1 << 8) | value0`

## Additional information
I have no idea if this is the same in every scenario.
For instance, in case fan1 is at address `0xC9`, is `0xC8` the first byte..?
Command used: `watch -d=cumulative -n 0.1 sudo isw -c` (with the original isw)