### PR TITLE
Fix Webcam checkbox flicker & Use Checkbox::clicked signal

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -356,7 +356,7 @@ void MainWindow::updateUsbPowerShareState() {
     ui->usbPowerShareCheckBox->setChecked(operate.getUsbPowerShareState());
 }
 
-void MainWindow::updateWebCamState() {
+void MainWindow::updateWebCamState() const {
     ui->webCamCheckBox->setChecked(operate.getWebCamState());
 }
 
@@ -652,6 +652,9 @@ void MainWindow::on_usbPowerShareCheckBox_toggled(bool checked) const {
 
 void MainWindow::on_webCamCheckBox_toggled(bool checked) const {
     operate.setWebCamState(checked);
+    if (operate.updateEcData()) {
+        updateWebCamState();
+    }
 }
 
 void MainWindow::on_fnSuperSwapCheckBox_toggled(bool checked) const {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -646,22 +646,22 @@ void MainWindow::on_WriteValueButton_clicked() const {
     operate.setValue(address, ui->ValueSpinBox->value());
 }
 
-void MainWindow::on_usbPowerShareCheckBox_toggled(bool checked) const {
+void MainWindow::on_usbPowerShareCheckBox_clicked(bool checked) const {
     operate.setUsbPowerShareState(checked);
 }
 
-void MainWindow::on_webCamCheckBox_toggled(bool checked) const {
+void MainWindow::on_webCamCheckBox_clicked(bool checked) const {
     operate.setWebCamState(checked);
     if (operate.updateEcData()) {
         updateWebCamState();
     }
 }
 
-void MainWindow::on_fnSuperSwapCheckBox_toggled(bool checked) const {
+void MainWindow::on_fnSuperSwapCheckBox_clicked(bool checked) const {
     operate.setFnSuperSwapState(checked);
 }
 
-void MainWindow::on_coolerBoostCheckBox_toggled(bool checked) const {
+void MainWindow::on_coolerBoostCheckBox_clicked(bool checked) const {
     if (operate.getCoolerBoostState() != checked)
         setCoolerBoostState(checked);
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -59,7 +59,7 @@ private:
     void updateKeyboardBacklightMode();
     void updateKeyboardBrightness();
     void updateUsbPowerShareState();
-    void updateWebCamState();
+    void updateWebCamState() const;
     void updateFnSuperSwapState();
     void updateCoolerBoostState() const;
     void updateUserMode();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -125,12 +125,12 @@ private slots:
 
     void on_WriteValueButton_clicked() const;
 
-    void on_usbPowerShareCheckBox_toggled(bool checked) const;
-    void on_webCamCheckBox_toggled(bool checked) const;
+    void on_usbPowerShareCheckBox_clicked(bool checked) const;
+    void on_webCamCheckBox_clicked(bool checked) const;
 
-    void on_fnSuperSwapCheckBox_toggled(bool checked) const;
+    void on_fnSuperSwapCheckBox_clicked(bool checked) const;
 
-    void on_coolerBoostCheckBox_toggled(bool checked) const;
+    void on_coolerBoostCheckBox_clicked(bool checked) const;
 
     void on_keyboardBrightnessSlider_valueChanged(int value) const;
 


### PR DESCRIPTION
The first commit is about the webcam checkbox. It flickers between ON and OFF when I click it.

This is because `MainWindow::updateData()` is called after the click, but **before** ecData is updated.
So the update contains the previous value.

Fixed by calling `updateEcData`, like in `MainWindow::setCoolerBoostState`


The second commit is about replacing Checkbox::toggled by Checkbox::clicked.
- Signal [CheckBox::toggled](https://doc.qt.io/qt-6/qabstractbutton.html#toggled) is also triggered when using setChecked, which is not what we want.
- Signal [CheckBox::clicked](https://doc.qt.io/qt-6/qabstractbutton.html#clicked) is triggered on user interactions only (click, touch, press space..), so I think it is more relevant.
