### PR TITLE
Add keyboard backlight support at address 0xF3

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -240,11 +240,15 @@ void MainWindow::loadConfigs() {
 
     updateFanSpeedSettings();
 
-    if (operate.isKeyboardBacklightSupport()) {
+    if (operate.isKeyboardBacklightModeSupport()) {
         updateKeyboardBacklightMode();
-        updateKeyboardBrightness();
     } else {
         ui->keyboardBacklightModeComboBox->setEnabled(false);
+    }
+
+    if (operate.isKeyboardBacklightSupport()) {
+        updateKeyboardBrightness();
+    } else {
         ui->keyboardBrightnessSlider->setEnabled(false);
     }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -352,7 +352,7 @@ void MainWindow::updateKeyboardBacklightMode() {
     ui->keyboardBacklightModeComboBox->setCurrentIndex(operate.getKeyboardBacklightMode());
 }
 
-void MainWindow::updateKeyboardBrightness() {
+void MainWindow::updateKeyboardBrightness() const {
     ui->keyboardBrightnessSlider->setSliderPosition(operate.getKeyboardBrightness());
 }
 
@@ -669,6 +669,9 @@ void MainWindow::on_coolerBoostCheckBox_toggled(bool checked) const {
 
 void MainWindow::on_keyboardBrightnessSlider_valueChanged(int value) const {
     operate.setKeyboardBrightness(value);
+    if (operate.updateEcData()) {
+        updateKeyboardBrightness();
+    }
 }
 
 void MainWindow::on_keyboardBacklightModeComboBox_currentIndexChanged(int index) const {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -57,7 +57,7 @@ private:
     void updateFan1Speed();
     void updateFan2Speed();
     void updateKeyboardBacklightMode();
-    void updateKeyboardBrightness();
+    void updateKeyboardBrightness() const;
     void updateUsbPowerShareState();
     void updateWebCamState();
     void updateFnSuperSwapState();

--- a/src/operate.cpp
+++ b/src/operate.cpp
@@ -40,7 +40,9 @@ const int keyboardBacklightModeAddress = 0x2C;
 const int keyboardBacklightAlwaysOn = 0x00;
 const int keyboardBacklightAutoTurnOff = 0x08;
 
-const int keyboardBacklightAddress = 0xD3;
+int keyboardBacklightAddress;
+const int keyboardBacklightAddress_0xD3 = 0xD3;
+const int keyboardBacklightAddress_0xF3 = 0xF3;
 const int keyboardBacklight0ff = 0x80;
 const int keyboardBacklightLow = 0x81;
 const int keyboardBacklightMid = 0x82;
@@ -113,6 +115,7 @@ bool Operate::doProbe() const {
     fan1Address = detectFan1Address();
     batteryThresholdAddress = detectBatteryThresholdAddress();
     fanModeAddress = detectFanModeAddress();
+    keyboardBacklightAddress = detectKeyboardBacklightAddress();
 
     return true;
 }
@@ -439,11 +442,19 @@ bool Operate::isBatteryThresholdSupport() const {
     return batteryThresholdAddress != 0;
 }
 
+bool Operate::isKeyboardBacklightModeSupport() const {
+    // Backlight mode is not available for all keyboard with backlight
+    
+    // Keep the same behaviour for devices with brightness at 0xD3
+    if (keyboardBacklightAddress == keyboardBacklightAddress_0xD3)
+        return true;
+    
+    // By security, we concider that devices with brightness at 0xF3 don't have backlight mode
+    return false;
+}
+
 bool Operate::isKeyboardBacklightSupport() const {
-    return (helper.getValue(keyboardBacklightAddress) == keyboardBacklight0ff ||
-            helper.getValue(keyboardBacklightAddress) == keyboardBacklightLow ||
-            helper.getValue(keyboardBacklightAddress) == keyboardBacklightMid ||
-            helper.getValue(keyboardBacklightAddress) == keyboardBacklightHigh);
+    return keyboardBacklightAddress != -1;
 }
 
 bool Operate::isUsbPowerShareSupport() const {
@@ -519,4 +530,24 @@ int Operate::detectFanModeAddress() const {
             fanModeValue == fanModeAdvanced)
         return fanModeAddress_0xD4;
     return fanModeAddress_0xF4;
+}
+
+int Operate::detectKeyboardBacklightAddress() const {
+    int value_0xD3 = helper.getValue(keyboardBacklightAddress_0xD3);
+    if (value_0xD3 == keyboardBacklight0ff ||
+        value_0xD3 == keyboardBacklightLow ||
+        value_0xD3 == keyboardBacklightMid ||
+        value_0xD3 == keyboardBacklightHigh) {
+        return keyboardBacklightAddress_0xD3;
+    }
+    
+    int value_0xF3 = helper.getValue(keyboardBacklightAddress_0xF3);
+    if (value_0xF3 == keyboardBacklight0ff ||
+        value_0xF3 == keyboardBacklightLow ||
+        value_0xF3 == keyboardBacklightMid ||
+        value_0xF3 == keyboardBacklightHigh) {
+        return keyboardBacklightAddress_0xF3;
+    }
+
+    return -1;
 }

--- a/src/operate.h
+++ b/src/operate.h
@@ -99,6 +99,7 @@ public:
     void setValue(int address, int value) const;
 
     [[nodiscard]] bool isBatteryThresholdSupport() const;
+    [[nodiscard]] bool isKeyboardBacklightModeSupport() const;
     [[nodiscard]] bool isKeyboardBacklightSupport() const;
     [[nodiscard]] bool isUsbPowerShareSupport() const;
     [[nodiscard]] bool isWebCamOffSupport() const;
@@ -110,6 +111,7 @@ private:
     int detectFan1Address() const;
     int detectBatteryThresholdAddress() const;
     int detectFanModeAddress() const;
+    int detectKeyboardBacklightAddress() const;
 };
 
 #endif // OPERATE_H


### PR DESCRIPTION
Previously, MControlCenter only checked for Keyboard Backlight/Brightness at `0xD3`.

This PR add support for brightness at `0xF3`.
The values are the same.

I am not aware of a "Keyboard Backlight Mode" on my device, and 0x2C contains another value (currently it's `0xC0`).
By security, I disabled "Keyboard Backlight Mode" if brightness is detected at `0xF3`.

Tested device:
- MSI Bravo 15 A4DDR, 16WKEMS1.105
