### PR TITLE
Detect sleep using QTimer and reapply Advanced Fan Mode after wakeup

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -158,6 +158,11 @@ MainWindow::MainWindow(QWidget *parent)
 
     connect(realtimeUpdateTimer, &QTimer::timeout, this, &MainWindow::realtimeUpdate);
     setUpdateInterval(1000);
+
+    // Timer to detect sleep and reapply Advanced Mode Fan if necessary
+    connect(&timerSleepWatcher, &QTimer::timeout, this, &MainWindow::timerSleepTimeout);
+    timerSleepWatcher.setInterval(10 * 1000);
+    timerSleepWatcher.start();
 }
 
 MainWindow::~MainWindow() {
@@ -598,6 +603,20 @@ void MainWindow::quitApp() const {
     Settings::setValue("MainWindow/Width", MainWindow::width());
     Settings::setValue("MainWindow/Height", MainWindow::height());
     (void) QCoreApplication::quit();
+}
+
+void MainWindow::timerSleepTimeout() {
+    qint64 timeNow = QDateTime::currentMSecsSinceEpoch();
+    if (timeLastWatcherInterval == 0) {
+        timeLastWatcherInterval = timeNow;
+        return;
+    }
+    qint64 msecsSinceTimeout = timeNow - timeLastWatcherInterval;
+    timeLastWatcherInterval = timeNow;
+    if (msecsSinceTimeout > timerSleepWatcher.interval() + 5000) {
+        // Went to sleep for at least 5 seconds
+        operate.handleWakeEvent();
+    }
 }
 
 void MainWindow::on_bestMobilityRadioButton_toggled(bool checked) {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -89,6 +89,10 @@ private:
     void closeEvent(QCloseEvent *event);
     void quitApp() const;
 
+    QTimer timerSleepWatcher;
+    qint64 timeLastWatcherInterval = 0;
+    void timerSleepTimeout();
+
     void createTrayIcon();
     void createActions();
     void iconActivated(QSystemTrayIcon::ActivationReason reason);

--- a/src/operate.cpp
+++ b/src/operate.cpp
@@ -487,6 +487,12 @@ void Operate::loadSettings() const {
         setFanModeAdvanced(s.getValue(settingsGroup + "fanModeAdvanced").toBool());
 }
 
+void Operate::handleWakeEvent() const {
+    Settings s;
+    if (s.isValueExist(settingsGroup + "fanModeAdvanced"))
+        setFanModeAdvanced(s.getValue(settingsGroup + "fanModeAdvanced").toBool());
+}
+
 void Operate::putSuperBatteryModeValue(bool enabled) const {
     if ((helper.getValue(superBatteryModeAddress) / 15 % 2 != 0) == enabled)
         return;

--- a/src/operate.h
+++ b/src/operate.h
@@ -104,6 +104,7 @@ public:
     [[nodiscard]] bool isWebCamOffSupport() const;
 
     void loadSettings() const;
+    void handleWakeEvent() const;
 
     void putSuperBatteryModeValue(bool enabled) const;
 private:


### PR DESCRIPTION
This is a workaround to detect if the device got into sleep mode (for at least 5 seconds).
When a wake-up is detected, Advanced Fan Mode is re-applied if needed.

This should fix #151, but there might be a better way to solve this issue.