### PR TITLE
[IMPORTANT] Handle non standard shift mode gracefully

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -390,9 +390,10 @@ void MainWindow::updateUserMode() {
                 ui->superBatteryModeRadioButton->click();
                 break;
             default:
-                ui->overviewTab->setDisabled(true);
-                if (modeTrayMenu)
-                    modeTrayMenu->setDisabled(true);
+                ui->superBatteryModeRadioButton->setChecked(0);
+                ui->silentModeRadioButton->setChecked(0);
+                ui->highPerformanceModeRadioButton->setChecked(0);
+                ui->balancedModeRadioButton->setChecked(0);
                 break;
         }
     }


### PR DESCRIPTION
some new models have a weird value after a cold boot that gets set to a standard value when you launch the official msi app, this is a problem on linux; the solution is to write any standard value (apply any shift mode through msi-ec) and it will behave normally.

this issue is slowing down testing for new devices because the app becomes greyed out if shift mode isn't a standard value.

please merge and release a new version if possible.

thanks in advance.