### PR TITLE
Handle GPU values with std::optional

### DIFF
--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -80,10 +80,14 @@ void Helper::callFinishedSlot(QDBusPendingCallWatcher *call) {
     call->deleteLater();
 }
 
-int Helper::getValue(int address) const {
+std::optional<int> Helper::getOptionalValue(int address) const {
     if (!ecData.isEmpty())
         return (BYTE) ecData[address];
-    return -1;
+    return std::nullopt;
+}
+
+int Helper::getValue(int address) const {
+    return getOptionalValue(address).value_or(-1);
 }
 
 QByteArray Helper::getValues(int startAddress, int size) const {

--- a/src/helper.h
+++ b/src/helper.h
@@ -33,6 +33,7 @@ public:
     bool loadEcSysModule();
     bool updateData();
     void updateDataAsync();
+    std::optional<int> getOptionalValue(int address) const;
     int getValue(int address) const;
     QByteArray getValues(int startAddress, int size) const;
     void putValue(int address, int value);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -359,10 +359,11 @@ void MainWindow::updateCpuTemp() {
 }
 
 void MainWindow::updateGpuTemp() {
-    if (operate.getGpuTemp() != 0) {
+    std::optional<int> temp = operate.getGpuTemp();
+    if (temp.has_value()) {
         ui->gpuTempValueLabel->setVisible(true);
         ui->gpuTempLabel->setVisible(true);
-        ui->gpuTempValueLabel->setText(intToQString(operate.getGpuTemp()) + " °C");
+        ui->gpuTempValueLabel->setText(intToQString(temp.value()) + " °C");
     } else {
         ui->gpuTempValueLabel->setVisible(false);
         ui->gpuTempLabel->setVisible(false);
@@ -374,10 +375,11 @@ void MainWindow::updateFan1Speed() {
 }
 
 void MainWindow::updateFan2Speed() {
-    if (operate.getFan2Speed() != 0) {
+    std::optional<int> speed = operate.getFan2Speed();
+    if (speed.has_value()) {
         ui->fan2ValueLabel->setVisible(true);
         ui->gpuFanLabel->setVisible(true);
-        ui->fan2ValueLabel->setText(intToQString(operate.getFan2Speed()) + " " + tr("rpm"));
+        ui->fan2ValueLabel->setText(intToQString(speed.value()) + " " + tr("rpm"));
     } else {
         ui->fan2ValueLabel->setVisible(false);
         ui->gpuFanLabel->setVisible(false);

--- a/src/msi-ec_helper.cpp
+++ b/src/msi-ec_helper.cpp
@@ -269,8 +269,8 @@ bool MsiEcHelper::hasGPURealtimeTemperature() const {
     return getValue<bool>("hasGPURealtimeTemperature", false);
 }
 
-int MsiEcHelper::getGPURealtimeTemperature() const {
-    return getValue<int>("getGPURealtimeTemperature", -1);
+std::optional<int> MsiEcHelper::getGPURealtimeTemperature() const {
+    return getOptionalValue<int>("getGPURealtimeTemperature");
 }
 
 // gpu/realtime_fan_speed 0-100 (percent)
@@ -278,8 +278,8 @@ bool MsiEcHelper::hasGPURealtimeFanSpeed() const {
     return getValue<bool>("hasGPURealtimeFanSpeed", false);
 }
 
-int MsiEcHelper::getGPURealtimeFanSpeed() const {
-    return getValue<int>("getGPURealtimeFanSpeed", -1);
+std::optional<int> MsiEcHelper::getGPURealtimeFanSpeed() const {
+    return getOptionalValue<int>("getGPURealtimeFanSpeed");
 }
 
 //////////////// Charge control ////////////////
@@ -351,11 +351,16 @@ void MsiEcHelper::printError(QDBusError const &error) const {
 }
 
 template <typename T>
-inline T MsiEcHelper::getValue(QString method, T defaultValue) const {
+inline std::optional<T> MsiEcHelper::getOptionalValue(QString method) const {
     if (QDBusReply<T> reply = iface->call(method); reply.isValid())
         return reply.value();
     printError(iface->lastError());
-    return defaultValue;
+    return std::nullopt;
+}
+
+template <typename T>
+inline T MsiEcHelper::getValue(QString method, T defaultValue) const {
+    return getOptionalValue<T>(method).value_or(defaultValue);
 }
 
 template <typename T>

--- a/src/msi-ec_helper.h
+++ b/src/msi-ec_helper.h
@@ -85,10 +85,10 @@ public:
 
     // gpu/realtime_temperature 0-100 (celsius scale)
     [[nodiscard]] bool hasGPURealtimeTemperature() const;
-    [[nodiscard]] int getGPURealtimeTemperature() const;
+    [[nodiscard]] std::optional<int> getGPURealtimeTemperature() const;
     // gpu/realtime_fan_speed 0-100 (percent)
     [[nodiscard]] bool hasGPURealtimeFanSpeed() const;
-    [[nodiscard]] int getGPURealtimeFanSpeed() const;
+    [[nodiscard]] std::optional<int> getGPURealtimeFanSpeed() const;
 
     // BAT1/charge_control_start_threshold 0-100 (percent)
     [[nodiscard]] bool hasBatteryStartThreshold() const;
@@ -117,6 +117,8 @@ private:
     QDBusInterface *iface;
     void printError(QDBusError const &error) const;
 
+    template <typename T>
+    [[nodiscard]] std::optional<T> getOptionalValue(QString method) const;
     template <typename T>
     [[nodiscard]] T getValue(QString method, T defaultValue) const;
     template <typename T>

--- a/src/operate.cpp
+++ b/src/operate.cpp
@@ -159,10 +159,10 @@ int Operate::getCpuTemp() const {
     return helper.getValue(cpuTempAddress);
 }
 
-int Operate::getGpuTemp() const {
+std::optional<int> Operate::getGpuTemp() const {
     if (msiEcHelper.hasGPURealtimeTemperature())
         return msiEcHelper.getGPURealtimeTemperature();
-    return helper.getValue(gpuTempAddress);
+    return helper.getOptionalValue(gpuTempAddress);
 }
 
 int Operate::getFan1Speed() const {
@@ -175,14 +175,16 @@ int Operate::getFan1Speed() const {
     return value;
 }
 
-int Operate::getFan2Speed() const {
+std::optional<int> Operate::getFan2Speed() const {
     // Read 2 bytes (big-endian)
-    int value0 = helper.getValue(fan2Address);
-    int value1 = helper.getValue(fan2Address - 1);
-    int value = (value1 << 8) | value0;
+    auto value0 = helper.getOptionalValue(fan2Address);
+    auto value1 = helper.getOptionalValue(fan2Address - 1);
+    if (!value0.has_value() || !value1.has_value())
+        return std::nullopt;
+    int value = (value1.value() << 8) | value0.value();
     if (value > 0)
         return 470000 / value;
-    return value;
+    return std::nullopt;
 }
 
 QVector<int> Operate::getFan1SpeedSettings() const {

--- a/src/operate.h
+++ b/src/operate.h
@@ -71,9 +71,9 @@ public:
     [[nodiscard]] int getBatteryThreshold() const;
     [[nodiscard]] charging_state getChargingStatus() const;
     [[nodiscard]] int getCpuTemp() const;
-    [[nodiscard]] int getGpuTemp() const;
+    [[nodiscard]] std::optional<int> getGpuTemp() const;
     [[nodiscard]] int getFan1Speed() const;
-    [[nodiscard]] int getFan2Speed() const;
+    [[nodiscard]] std::optional<int> getFan2Speed() const;
     [[nodiscard]] QVector<int> getFan1SpeedSettings() const;
     [[nodiscard]] QVector<int> getFan2SpeedSettings() const;
     [[nodiscard]] QVector<int> getFan1TempSettings() const;


### PR DESCRIPTION
Use nullopt instead of -1 when there is no GPU.
Fix GPU temp and fan speed hiding when GPU turns off.
close #248