### PR TITLE
Improve GPU labels hiding logic

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -359,10 +359,12 @@ void MainWindow::updateCpuTemp() {
 }
 
 void MainWindow::updateGpuTemp() {
-    if (operate.getGpuTemp() != 0) {
-        ui->gpuTempValueLabel->setVisible(true);
-        ui->gpuTempLabel->setVisible(true);
-        ui->gpuTempValueLabel->setText(intToQString(operate.getGpuTemp()) + " °C");
+    if (operate.hasGpuTemp()) {
+        if (operate.getGpuTemp() != 0) {
+            ui->gpuTempValueLabel->setText(intToQString(operate.getGpuTemp()) + " °C");
+        } else {
+            ui->gpuTempValueLabel->setText(tr("OFF"));
+        }
     } else {
         ui->gpuTempValueLabel->setVisible(false);
         ui->gpuTempLabel->setVisible(false);
@@ -374,9 +376,7 @@ void MainWindow::updateFan1Speed() {
 }
 
 void MainWindow::updateFan2Speed() {
-    if (operate.getFan2Speed() != 0) {
-        ui->fan2ValueLabel->setVisible(true);
-        ui->gpuFanLabel->setVisible(true);
+    if (operate.hasGpuFanSpeed()) {
         ui->fan2ValueLabel->setText(intToQString(operate.getFan2Speed()) + " " + tr("rpm"));
     } else {
         ui->fan2ValueLabel->setVisible(false);

--- a/src/operate.cpp
+++ b/src/operate.cpp
@@ -159,10 +159,22 @@ int Operate::getCpuTemp() const {
     return helper.getValue(cpuTempAddress);
 }
 
+bool Operate::hasGpuTemp() const {
+    if (msiEcHelper.hasGPURealtimeTemperature())
+        return true;
+    return false;
+}
+
 int Operate::getGpuTemp() const {
     if (msiEcHelper.hasGPURealtimeTemperature())
         return msiEcHelper.getGPURealtimeTemperature();
     return helper.getValue(gpuTempAddress);
+}
+
+bool Operate::hasGpuFanSpeed() const {
+    if (msiEcHelper.hasGPURealtimeFanSpeed())
+        return true;
+    return false;
 }
 
 int Operate::getFan1Speed() const {

--- a/src/operate.h
+++ b/src/operate.h
@@ -71,8 +71,10 @@ public:
     [[nodiscard]] int getBatteryThreshold() const;
     [[nodiscard]] charging_state getChargingStatus() const;
     [[nodiscard]] int getCpuTemp() const;
+    [[nodiscard]] bool hasGpuTemp() const;
     [[nodiscard]] int getGpuTemp() const;
     [[nodiscard]] int getFan1Speed() const;
+    [[nodiscard]] bool hasGpuFanSpeed() const;
     [[nodiscard]] int getFan2Speed() const;
     [[nodiscard]] QVector<int> getFan1SpeedSettings() const;
     [[nodiscard]] QVector<int> getFan2SpeedSettings() const;


### PR DESCRIPTION
only hides for laptops that don't report GPU temp or speed

check sysfs files with msi-ec, but still calculate speed from ec directly