### PR TITLE
Fix loading fan mode advances after restart and wake-up

### DIFF
--- a/src/operate.cpp
+++ b/src/operate.cpp
@@ -544,13 +544,13 @@ void Operate::loadSettings() const {
         setUsbPowerShareState(s.getValue(settingsGroup + "UsbPowerShare").toBool());
 
     if (s.isValueExist(settingsGroup + "fan1SpeedSettings"))
-    setFan1SpeedSettings(s.getValueVector(settingsGroup + "fan1SpeedSettings"));
+        setFan1SpeedSettings(s.getValueVector(settingsGroup + "fan1SpeedSettings"));
     if (s.isValueExist(settingsGroup + "fan2SpeedSettings"))
-    setFan2SpeedSettings(s.getValueVector(settingsGroup + "fan2SpeedSettings"));
+        setFan2SpeedSettings(s.getValueVector(settingsGroup + "fan2SpeedSettings"));
     if (s.isValueExist(settingsGroup + "fan1TempSettings"))
-    setFan1TempSettings(s.getValueVector(settingsGroup + "fan1TempSettings"));
+        setFan1TempSettings(s.getValueVector(settingsGroup + "fan1TempSettings"));
     if (s.isValueExist(settingsGroup + "fan2TempSettings"))
-    setFan2TempSettings(s.getValueVector(settingsGroup + "fan2TempSettings"));
+        setFan2TempSettings(s.getValueVector(settingsGroup + "fan2TempSettings"));
     if (s.isValueExist(settingsGroup + "fanModeAdvanced"))
         setFanModeAdvanced(s.getValue(settingsGroup + "fanModeAdvanced").toBool());
 }


### PR DESCRIPTION
When MControlCenter is first loaded, the advanced fan mode is not set correctly if enabled. This is due to a race condition between setUserMode which sets it to auto using MsiEcHelper (which is async), and loadSettings using the old putValue.

Also in my case (Raider GE67HX 12UGS) after wake-up the fans' curves are reset by the firmware, so I updated the handleWakeEvent to reload them.