### PR TITLE
Ignore current user mode when loading settings and restore after sleep

### DIFF
--- a/src/operate.cpp
+++ b/src/operate.cpp
@@ -552,9 +552,7 @@ void Operate::loadSettings() const {
 }
 
 void Operate::handleWakeEvent() const {
-    Settings s;
-    if (s.isValueExist(settingsGroup + "fanModeAdvanced"))
-        setFanModeAdvanced(s.getValue(settingsGroup + "fanModeAdvanced").toBool());
+    loadSettings();
 }
 
 int Operate::detectFan1Address() const {

--- a/src/operate.cpp
+++ b/src/operate.cpp
@@ -522,7 +522,7 @@ bool Operate::isWebCamOffSupport() const {
 void Operate::loadSettings() const {
     Settings s;
 
-    if (getUserMode() != user_mode::unknown_mode && s.isValueExist(settingsGroup + "UserMode")) {
+    if (msiEcHelper.hasShiftMode() && s.isValueExist(settingsGroup + "UserMode")) {
         QString value = s.getValue(settingsGroup + "UserMode").toString();
         if (value == "balanced_mode")
             setUserMode(user_mode::balanced_mode);


### PR DESCRIPTION
The user mode is unknown when starting/waking from sleep on my laptop (0x8X instead of 0xCX values).

Related to #303 and more effective with it.
As mentioned in https://github.com/dmitry-s93/MControlCenter/pull/303#issuecomment-4102242861, the unknown state prevents setUserMode from running, so I still have auto after waking from sleep.

We use msi-ec now, we can trust it.

IMO loadSettings makes sense. At least these settings reset when going to sleep:
- User mode
- Fan mode
- FN/Meta swap
- Fan curve (note that it will break this procedure https://github.com/dmitry-s93/MControlCenter/pull/303#issuecomment-4104298315)