### PR TITLE
Feature/system76 power integration

### DIFF
--- a/src/i18n/MControlCenter_de_DE.ts
+++ b/src/i18n/MControlCenter_de_DE.ts
@@ -156,6 +156,16 @@
         <translation>Erweitert</translation>
     </message>
     <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to a power profile service.
+Make sure that Power Profiles Daemon, TuneD, or system76-power is installed and restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cooling</source>
         <translation>Kühlen</translation>
     </message>
@@ -214,6 +224,22 @@
     <message>
         <source>Current fan Mode:</source>
         <translation>Aktueller Lüftermodus:</translation>
+    </message>
+    <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Keyboard</source>

--- a/src/i18n/MControlCenter_en.ts
+++ b/src/i18n/MControlCenter_en.ts
@@ -116,16 +116,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Couldn&apos;t connect to UPower to get charger status.
-Make sure that UPower is installed and running then restart the app.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Couldn&apos;t connect to Power Profiles Daemon.
-Make sure that either Power Profiles Daemon or TuneD is installed and restart the app.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -163,6 +153,16 @@ Make sure that either Power Profiles Daemon or TuneD is installed and restart th
     </message>
     <message>
         <source>Advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to a power profile service.
+Make sure that Power Profiles Daemon, TuneD, or system76-power is installed and restart the system.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/MControlCenter_es.ts
+++ b/src/i18n/MControlCenter_es.ts
@@ -156,6 +156,16 @@
         <translation>Avanzado</translation>
     </message>
     <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to a power profile service.
+Make sure that Power Profiles Daemon, TuneD, or system76-power is installed and restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cooling</source>
         <translation>Enfriamiento</translation>
     </message>
@@ -244,7 +254,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>If you mainly use your laptop with the charger plugged most of the time, it is recommended to set the charge capacity at a lower percentage (60% or 80%) to prolong your battery lifecycle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/MControlCenter_eu.ts
+++ b/src/i18n/MControlCenter_eu.ts
@@ -156,6 +156,16 @@
         <translation>Aurreratua</translation>
     </message>
     <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to a power profile service.
+Make sure that Power Profiles Daemon, TuneD, or system76-power is installed and restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cooling</source>
         <translation>Hoztu</translation>
     </message>
@@ -244,7 +254,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>If you mainly use your laptop with the charger plugged most of the time, it is recommended to set the charge capacity at a lower percentage (60% or 80%) to prolong your battery lifecycle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/MControlCenter_fi_FI.ts
+++ b/src/i18n/MControlCenter_fi_FI.ts
@@ -156,6 +156,16 @@
         <translation>Edistynyt</translation>
     </message>
     <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to a power profile service.
+Make sure that Power Profiles Daemon, TuneD, or system76-power is installed and restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cooling</source>
         <translation>Jäähdytys</translation>
     </message>
@@ -244,7 +254,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>If you mainly use your laptop with the charger plugged most of the time, it is recommended to set the charge capacity at a lower percentage (60% or 80%) to prolong your battery lifecycle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/MControlCenter_fr.ts
+++ b/src/i18n/MControlCenter_fr.ts
@@ -156,6 +156,16 @@
         <translation>Avancé</translation>
     </message>
     <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to a power profile service.
+Make sure that Power Profiles Daemon, TuneD, or system76-power is installed and restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cooling</source>
         <translation>Refroidissement</translation>
     </message>
@@ -244,8 +254,24 @@
         <translation>Performances maximales au prix de la chaleur et d&apos;une consommation électrique accrue</translation>
     </message>
     <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>If you mainly use your laptop with the charger plugged most of the time, it is recommended to set the charge capacity at a lower percentage (60% or 80%) to prolong your battery lifecycle.</source>
         <translation>Si vous utilisez principalement votre ordinateur avec le chargeur branché, il est recommandé de mettre la limite de charge à un pourcentage plus bas (60&#xa0;% ou 80&#xa0;%) pour prolonger la durée de vie de votre batterie.</translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charge the battery when under 90%, stop at 100%</source>

--- a/src/i18n/MControlCenter_hu.ts
+++ b/src/i18n/MControlCenter_hu.ts
@@ -156,6 +156,16 @@
         <translation>Haladó</translation>
     </message>
     <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to a power profile service.
+Make sure that Power Profiles Daemon, TuneD, or system76-power is installed and restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cooling</source>
         <translation>Hűtés</translation>
     </message>
@@ -244,7 +254,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>If you mainly use your laptop with the charger plugged most of the time, it is recommended to set the charge capacity at a lower percentage (60% or 80%) to prolong your battery lifecycle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/MControlCenter_it.ts
+++ b/src/i18n/MControlCenter_it.ts
@@ -156,6 +156,16 @@
         <translation>Avanzato</translation>
     </message>
     <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to a power profile service.
+Make sure that Power Profiles Daemon, TuneD, or system76-power is installed and restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cooling</source>
         <translation>Raffreddamento</translation>
     </message>
@@ -244,7 +254,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>If you mainly use your laptop with the charger plugged most of the time, it is recommended to set the charge capacity at a lower percentage (60% or 80%) to prolong your battery lifecycle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/MControlCenter_nb.ts
+++ b/src/i18n/MControlCenter_nb.ts
@@ -156,6 +156,16 @@
         <translation>Avansert</translation>
     </message>
     <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to a power profile service.
+Make sure that Power Profiles Daemon, TuneD, or system76-power is installed and restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cooling</source>
         <translation>Kjøling</translation>
     </message>
@@ -244,7 +254,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>If you mainly use your laptop with the charger plugged most of the time, it is recommended to set the charge capacity at a lower percentage (60% or 80%) to prolong your battery lifecycle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/MControlCenter_nl_NL.ts
+++ b/src/i18n/MControlCenter_nl_NL.ts
@@ -156,6 +156,16 @@
         <translation>Geavanceerd</translation>
     </message>
     <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to a power profile service.
+Make sure that Power Profiles Daemon, TuneD, or system76-power is installed and restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cooling</source>
         <translation>Koelen</translation>
     </message>
@@ -244,7 +254,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>If you mainly use your laptop with the charger plugged most of the time, it is recommended to set the charge capacity at a lower percentage (60% or 80%) to prolong your battery lifecycle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/MControlCenter_pt_BR.ts
+++ b/src/i18n/MControlCenter_pt_BR.ts
@@ -9,15 +9,15 @@
     </message>
     <message>
         <source>EC Build:</source>
-        <translation>Compilação do EC:</translation>
+        <translation>Build do EC:</translation>
     </message>
     <message>
         <source>Battery charge:</source>
-        <translation>Carga da bateria:</translation>
+        <translation>Carregando:</translation>
     </message>
     <message>
         <source>Battery threshold:</source>
-        <translation>Limite da bateria:</translation>
+        <translation>Limitador de carga da bateria:</translation>
     </message>
     <message>
         <source>CPU temp:</source>
@@ -29,7 +29,7 @@
     </message>
     <message>
         <source>Cooler Boost</source>
-        <translation>Impulsionar Ventoinha</translation>
+        <translation>Ventoinha com Esteróides</translation>
     </message>
     <message>
         <source>Battery</source>
@@ -69,7 +69,7 @@
     </message>
     <message>
         <source>WebCam</source>
-        <translation>Câmara de Web</translation>
+        <translation>Câmara</translation>
     </message>
     <message>
         <source>Debug</source>
@@ -89,15 +89,15 @@
     </message>
     <message>
         <source>Charging</source>
-        <translation>A carregar</translation>
+        <translation>Carregando</translation>
     </message>
     <message>
         <source>Discharging</source>
-        <translation>A descarregar</translation>
+        <translation>Descarregando</translation>
     </message>
     <message>
         <source>Not charging</source>
-        <translation>Não está a carregar</translation>
+        <translation>Não está carregando</translation>
     </message>
     <message>
         <source>Unknown</source>
@@ -169,136 +169,165 @@
     </message>
     <message>
         <source>Reset</source>
-        <translation>Repor</translation>
+        <translation>Resetar</translation>
     </message>
     <message>
         <source>Fan control</source>
-        <translation>Controlo da ventoinha</translation>
+        <translation>Controle da ventoinha</translation>
     </message>
     <message>
         <source>Enable advanced fan control</source>
-        <translation>Habilitar controlo avançado da ventoinha</translation>
+        <translation>Habilitar controle avançado da ventoinha</translation>
     </message>
     <message>
         <source>Overview</source>
-        <translation type="unfinished"></translation>
+        <translation>Resumo</translation>
     </message>
     <message>
         <source>The middle spot between fan noise and power usage</source>
-        <translation type="unfinished"></translation>
+        <translation>O equilíbrio entre consumo e barulho da ventoinha</translation>
     </message>
     <message>
         <source>Low fan noise and moderate power usage</source>
-        <translation type="unfinished"></translation>
+        <translation>Baixo barulho da ventoinha e consumo moderado</translation>
     </message>
     <message>
         <source>Limits performance and turns off fans at lower temperatures</source>
-        <translation type="unfinished"></translation>
+        <translation>Limita a performance e desliga as ventoinhas em baixas temperaturas</translation>
     </message>
     <message>
         <source>GPU Fan:</source>
-        <translation type="unfinished"></translation>
+        <translation>Ventoinha da GPU</translation>
     </message>
     <message>
         <source>CPU Fan:</source>
-        <translation type="unfinished"></translation>
+        <translation>Ventoinha da CPU</translation>
     </message>
     <message>
         <source>USB Power</source>
-        <translation type="unfinished"></translation>
+        <translation>USB Power</translation>
     </message>
     <message>
         <source>FN ⇄ Meta</source>
-        <translation type="unfinished"></translation>
+        <translation>FN ⇄ Meta</translation>
     </message>
     <message>
         <source>Current fan Mode:</source>
-        <translation type="unfinished"></translation>
+        <translation>Modo atual da ventoinha</translation>
     </message>
     <message>
         <source>Keyboard</source>
-        <translation type="unfinished"></translation>
+        <translation>Teclado</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;MC&lt;/span&gt;ontrol&lt;span style=&quot; font-weight:700;&quot;&gt;C&lt;/span&gt;enter (MCC) is an application that allows you to change the settings of MSI laptops running Linux.&lt;/p&gt;&lt;p&gt;MCC acts as a graphical interface for the &lt;span style=&quot; font-weight:700;&quot;&gt;MSI-EC &lt;/span&gt;driver that already exist in the Linux kernel, if your device is not supported (grey buttons/limited in-app functionality), please visit the msi-ec github page to get help.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;MC&lt;/span&gt;ontrol&lt;span style=&quot; font-weight:700;&quot;&gt;C&lt;/span&gt;enter (MCC) é uma aplicação que permite alterar as configurações de notebooks MSI rodando Linux.&lt;/p&gt;&lt;p&gt;O MCC atua como uma interface gráfica para o driver &lt;span style=&quot; font-weight:700;&quot;&gt;MSI-EC&lt;/span&gt; que já existe no kernel Linux. Se o seu dispositivo não for suportado (botões cinza/funcionalidade limitada), visite a página do msi-ec no GitHub para obter ajuda.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>MCC GitHub:</source>
-        <translation type="unfinished"></translation>
+        <translation>MCC GitHub:</translation>
     </message>
     <message>
         <source>MSI-EC GitHub:</source>
-        <translation type="unfinished"></translation>
+        <translation>MSI-EC GitHub:</translation>
     </message>
     <message>
         <source>This mode unlocks Advanced fan mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Este modo desbloqueia o modo Avançado de ventoinha</translation>
     </message>
     <message>
         <source>High Performance</source>
-        <translation type="unfinished"></translation>
+        <translation>Alta Performance</translation>
     </message>
     <message>
         <source>Maximum performance at the cost of heat and increased power consumption</source>
-        <translation type="unfinished"></translation>
+        <translation>Performance máxima ao custo de aquecimento e maior consumo de energia</translation>
     </message>
     <message>
         <source>If you mainly use your laptop with the charger plugged most of the time, it is recommended to set the charge capacity at a lower percentage (60% or 80%) to prolong your battery lifecycle.</source>
-        <translation type="unfinished"></translation>
+        <translation>Se você utiliza seu notebook com o carregador conectado na maior parte do tempo, é recomendado definir a capacidade de carga em uma porcentagem menor (60% ou 80%) para prolongar a vida útil da bateria.</translation>
     </message>
     <message>
         <source>Charge the battery when under 90%, stop at 100%</source>
-        <translation type="unfinished"></translation>
+        <translation>Carregar a bateria quando estiver abaixo de 90%, parar a 100%</translation>
     </message>
     <message>
         <source>Keyboard Backlight</source>
-        <translation type="unfinished"></translation>
+        <translation>Luz de Fundo do Teclado</translation>
     </message>
     <message>
         <source>-</source>
-        <translation type="unfinished"></translation>
+        <translation>-</translation>
     </message>
     <message>
         <source>MCC Bug Tracker:</source>
-        <translation type="unfinished"></translation>
+        <translation>MCC Bug Tracker:</translation>
     </message>
     <message>
         <source>Qt version:</source>
-        <translation type="unfinished"></translation>
+        <translation>Versão Qt:</translation>
     </message>
     <message>
         <source>MSI-EC Status:</source>
-        <translation type="unfinished"></translation>
+        <translation>Status MSI-EC:</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Warning&lt;/span&gt;: Writing the wrong values to the wrong addresses &lt;span style=&quot; font-weight:700;&quot;&gt;WILL BRICK YOUR DEVICE!&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Never&lt;/span&gt; write to EC memory without knowing how to do a proper &lt;span style=&quot; font-weight:700;&quot;&gt;BIOS/EC&lt;/span&gt; reset, keep in mind that a reset &lt;span style=&quot; font-weight:700;&quot;&gt;might not&lt;/span&gt; fix the device if the device got bricked/broken. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Aviso&lt;/span&gt;: Escrever valores errados nos endereços errados &lt;span style=&quot; font-weight:700;&quot;&gt;VAI BRICKAR SEU DISPOSITIVO!&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Nunca&lt;/span&gt; escreva na memória do EC sem saber como fazer um reset adequado de &lt;span style=&quot; font-weight:700;&quot;&gt;BIOS/EC&lt;/span&gt;. Tenha em mente que um reset &lt;span style=&quot; font-weight:700;&quot;&gt;pode não&lt;/span&gt; corrigir o dispositivo se ele foi brickado/danificado.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>The msi-ec module is not loaded/installed.
 Check the &lt;About&gt; page for more info.</source>
-        <translation type="unfinished"></translation>
+        <translation>O módulo msi-ec não está carregado/instalado.
+Verifique a página &lt;Sobre&gt; para mais informações.</translation>
     </message>
     <message>
         <source>The ec_sys module couldn&apos;t be detected, it might be required to control the fans.</source>
-        <translation type="unfinished"></translation>
+        <translation>O módulo ec_sys não foi detectado, ele pode ser necessário para controlar as ventoinhas.</translation>
     </message>
     <message>
         <source>Loaded</source>
-        <translation type="unfinished"></translation>
+        <translation>Carregado</translation>
     </message>
     <message>
         <source>Fallback: Only ec_sys is loaded</source>
-        <translation type="unfinished"></translation>
+        <translation>Fallback: Apenas ec_sys está carregado</translation>
     </message>
     <message>
         <source>Failed to load both msi-ec/ec_sys</source>
-        <translation type="unfinished"></translation>
+        <translation>Falha ao carregar msi-ec/ec_sys</translation>
     </message>
     <message>
         <source>OFF</source>
-        <translation type="unfinished"></translation>
+        <translation>DESLIGADO</translation>
+    </message>
+    <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation>Seguir o perfil de energia do sistema</translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation>Troca Automática de Perfil</translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation>Carregando:</translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
+        <translation>Descarregando:</translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation>Não foi possível conectar ao UPower para obter o estado do carregador.
+Certifique-se de que o UPower está instalado e em execução e reinicie o sistema.</translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to a power profile service.
+Make sure that Power Profiles Daemon, TuneD, or system76-power is installed and restart the system.</source>
+        <translation>Não foi possível conectar a um serviço de perfil de energia.
+Certifique-se de que o Power Profiles Daemon, TuneD ou system76-power está instalado e reinicie o sistema.</translation>
     </message>
 </context>
 </TS>

--- a/src/i18n/MControlCenter_pt_BR.ts
+++ b/src/i18n/MControlCenter_pt_BR.ts
@@ -29,7 +29,7 @@
     </message>
     <message>
         <source>Cooler Boost</source>
-        <translation>Ventoinha com Esteróides</translation>
+        <translation>Ventoinha com Esteroides</translation>
     </message>
     <message>
         <source>Battery</source>
@@ -69,7 +69,7 @@
     </message>
     <message>
         <source>WebCam</source>
-        <translation>Câmara</translation>
+        <translation>Câmera</translation>
     </message>
     <message>
         <source>Debug</source>
@@ -273,7 +273,7 @@
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Warning&lt;/span&gt;: Writing the wrong values to the wrong addresses &lt;span style=&quot; font-weight:700;&quot;&gt;WILL BRICK YOUR DEVICE!&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Never&lt;/span&gt; write to EC memory without knowing how to do a proper &lt;span style=&quot; font-weight:700;&quot;&gt;BIOS/EC&lt;/span&gt; reset, keep in mind that a reset &lt;span style=&quot; font-weight:700;&quot;&gt;might not&lt;/span&gt; fix the device if the device got bricked/broken. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Aviso&lt;/span&gt;: Escrever valores errados nos endereços errados &lt;span style=&quot; font-weight:700;&quot;&gt;VAI BRICKAR SEU DISPOSITIVO!&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Nunca&lt;/span&gt; escreva na memória do EC sem saber como fazer um reset adequado de &lt;span style=&quot; font-weight:700;&quot;&gt;BIOS/EC&lt;/span&gt;. Tenha em mente que um reset &lt;span style=&quot; font-weight:700;&quot;&gt;pode não&lt;/span&gt; corrigir o dispositivo se ele foi brickado/danificado.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Aviso&lt;/span&gt;: Escrever valores errados nos endereços errados &lt;span style=&quot; font-weight:700;&quot;&gt;VAI QUEBRAR SEU DISPOSITIVO!&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Nunca&lt;/span&gt; escrever na memória do EC sem saber como fazer um reset adequado de &lt;span style=&quot; font-weight:700;&quot;&gt;BIOS/EC&lt;/span&gt;. Tenha em mente que um reset &lt;span style=&quot; font-weight:700;&quot;&gt;pode não&lt;/span&gt; corrigir o dispositivo se ele foi quebrado/danificado.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>The msi-ec module is not loaded/installed.
@@ -320,7 +320,7 @@ Verifique a página &lt;Sobre&gt; para mais informações.</translation>
     <message>
         <source>Couldn&apos;t connect to UPower to get charger status.
 Make sure that UPower is installed and running then restart the system.</source>
-        <translation>Não foi possível conectar ao UPower para obter o estado do carregador.
+        <translation>Não foi possível conectar ao UPower para obter o estado de carregamento.
 Certifique-se de que o UPower está instalado e em execução e reinicie o sistema.</translation>
     </message>
     <message>

--- a/src/i18n/MControlCenter_pt_BR.ts
+++ b/src/i18n/MControlCenter_pt_BR.ts
@@ -156,6 +156,17 @@
         <translation>Avançado</translation>
     </message>
     <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to a power profile service.
+Make sure that Power Profiles Daemon, TuneD, or system76-power is installed and restart the system.</source>
+        <translation>Não foi possível conectar a um serviço de perfil de energia.
+Certifique-se de que o Power Profiles Daemon, TuneD ou system76-power está instalado e reinicie o sistema.</translation>
+    </message>
+    <message>
         <source>Cooling</source>
         <translation>Arrefecimento</translation>
     </message>
@@ -244,7 +255,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>If you mainly use your laptop with the charger plugged most of the time, it is recommended to set the charge capacity at a lower percentage (60% or 80%) to prolong your battery lifecycle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/MControlCenter_pt_PT.ts
+++ b/src/i18n/MControlCenter_pt_PT.ts
@@ -156,6 +156,16 @@
         <translation>Avançado</translation>
     </message>
     <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to a power profile service.
+Make sure that Power Profiles Daemon, TuneD, or system76-power is installed and restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cooling</source>
         <translation>Arrefecimento</translation>
     </message>
@@ -244,7 +254,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>If you mainly use your laptop with the charger plugged most of the time, it is recommended to set the charge capacity at a lower percentage (60% or 80%) to prolong your battery lifecycle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/MControlCenter_ru.ts
+++ b/src/i18n/MControlCenter_ru.ts
@@ -156,6 +156,16 @@
         <translation>Расширенный</translation>
     </message>
     <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to a power profile service.
+Make sure that Power Profiles Daemon, TuneD, or system76-power is installed and restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cooling</source>
         <translation>Охлаждение</translation>
     </message>
@@ -214,6 +224,22 @@
     <message>
         <source>Current fan Mode:</source>
         <translation>Режим вентилятора:</translation>
+    </message>
+    <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Keyboard</source>

--- a/src/i18n/MControlCenter_tr.ts
+++ b/src/i18n/MControlCenter_tr.ts
@@ -159,6 +159,16 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to a power profile service.
+Make sure that Power Profiles Daemon, TuneD, or system76-power is installed and restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cooling</source>
         <translation type="unfinished"></translation>
     </message>
@@ -247,7 +257,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>If you mainly use your laptop with the charger plugged most of the time, it is recommended to set the charge capacity at a lower percentage (60% or 80%) to prolong your battery lifecycle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/MControlCenter_vi.ts
+++ b/src/i18n/MControlCenter_vi.ts
@@ -156,6 +156,16 @@
         <translation>Nâng cao</translation>
     </message>
     <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to a power profile service.
+Make sure that Power Profiles Daemon, TuneD, or system76-power is installed and restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cooling</source>
         <translation>Tản nhiệt</translation>
     </message>
@@ -244,7 +254,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>If you mainly use your laptop with the charger plugged most of the time, it is recommended to set the charge capacity at a lower percentage (60% or 80%) to prolong your battery lifecycle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/MControlCenter_zh_CN.ts
+++ b/src/i18n/MControlCenter_zh_CN.ts
@@ -156,6 +156,16 @@
         <translation>高级（手动）</translation>
     </message>
     <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to a power profile service.
+Make sure that Power Profiles Daemon, TuneD, or system76-power is installed and restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cooling</source>
         <translation>冷却选项</translation>
     </message>
@@ -244,7 +254,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>If you mainly use your laptop with the charger plugged most of the time, it is recommended to set the charge capacity at a lower percentage (60% or 80%) to prolong your battery lifecycle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -843,6 +843,7 @@ void MainWindow::on_autoAcDcProfilesGroupBox_toggled(bool checked) {
         }
 
         powerMonitor.disconnectFromPowerProfiles();
+        powerMonitor.disconnectFromSystem76Power();
         ui->autoPPDCheckBox->setChecked(0);
         ui->autoPPDCheckBox->setEnabled(0);
         powerMonitor.queryChargerState();
@@ -858,10 +859,15 @@ void MainWindow::on_autoPPDCheckBox_toggled(bool checked) {
     if (checked) {
 
         if (!powerMonitor.connectToPowerProfiles()) {
-            QMessageBox::critical(nullptr, this->windowTitle(), tr("Couldn't connect to Power Profiles Daemon.\n"
-                                                                   "Make sure that either Power Profiles Daemon or TuneD is installed and restart the system."));
-            ui->autoPPDCheckBox->setChecked(0);
-            return;
+            if (!powerMonitor.connectToSystem76Power()) {
+                QMessageBox::critical(nullptr, this->windowTitle(), tr("Couldn't connect to a power profile service.\n"
+                                                                       "Make sure that Power Profiles Daemon, TuneD, or system76-power is installed and restart the system."));
+                ui->autoPPDCheckBox->setChecked(0);
+                return;
+            }
+            powerMonitor.querySystem76Profile();
+        } else {
+            powerMonitor.queryPowerProfile();
         }
 
         powerMonitor.disconnectFromUpower();
@@ -871,13 +877,14 @@ void MainWindow::on_autoPPDCheckBox_toggled(bool checked) {
         ui->superBatteryModeRadioButton->setEnabled(0);
         ui->autoAcDcProfilesGroupBox->setChecked(0);
         ui->autoAcDcProfilesGroupBox->setEnabled(0);
-        powerMonitor.queryPowerProfile();
     } else {
         ui->highPerformanceModeRadioButton->setEnabled(1);
         ui->balancedModeRadioButton->setEnabled(1);
         ui->silentModeRadioButton->setEnabled(1);
         ui->superBatteryModeRadioButton->setEnabled(1);
         ui->autoAcDcProfilesGroupBox->setEnabled(1);
+        powerMonitor.disconnectFromPowerProfiles();
+        powerMonitor.disconnectFromSystem76Power();
     }
     Settings::setValue("Settings/autoPPDstate", checked);
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -843,6 +843,7 @@ void MainWindow::on_autoAcDcProfilesGroupBox_toggled(bool checked) {
         }
 
         powerMonitor.disconnectFromPowerProfiles();
+        powerMonitor.disconnectFromSystem76Power();
         ui->autoPPDCheckBox->setChecked(0);
         ui->autoPPDCheckBox->setEnabled(0);
         powerMonitor.queryChargerState();
@@ -856,10 +857,13 @@ void MainWindow::on_autoAcDcProfilesGroupBox_toggled(bool checked) {
 
 void MainWindow::on_autoPPDCheckBox_toggled(bool checked) {
     if (checked) {
-
-        if (!powerMonitor.connectToPowerProfiles()) {
-            QMessageBox::critical(nullptr, this->windowTitle(), tr("Couldn't connect to Power Profiles Daemon.\n"
-                                                                   "Make sure that either Power Profiles Daemon or TuneD is installed and restart the system."));
+        if (powerMonitor.connectToSystem76Power()) {
+            powerMonitor.querySystem76Profile();
+        } else if (powerMonitor.connectToPowerProfiles()) {
+            powerMonitor.queryPowerProfile();
+        } else {
+            QMessageBox::critical(nullptr, this->windowTitle(), tr("Couldn't connect to a power profile service.\n"
+                                                                   "Make sure that Power Profiles Daemon, TuneD, or system76-power is installed and restart the system."));
             ui->autoPPDCheckBox->setChecked(0);
             return;
         }
@@ -871,13 +875,14 @@ void MainWindow::on_autoPPDCheckBox_toggled(bool checked) {
         ui->superBatteryModeRadioButton->setEnabled(0);
         ui->autoAcDcProfilesGroupBox->setChecked(0);
         ui->autoAcDcProfilesGroupBox->setEnabled(0);
-        powerMonitor.queryPowerProfile();
     } else {
         ui->highPerformanceModeRadioButton->setEnabled(1);
         ui->balancedModeRadioButton->setEnabled(1);
         ui->silentModeRadioButton->setEnabled(1);
         ui->superBatteryModeRadioButton->setEnabled(1);
         ui->autoAcDcProfilesGroupBox->setEnabled(1);
+        powerMonitor.disconnectFromPowerProfiles();
+        powerMonitor.disconnectFromSystem76Power();
     }
     Settings::setValue("Settings/autoPPDstate", checked);
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -857,17 +857,15 @@ void MainWindow::on_autoAcDcProfilesGroupBox_toggled(bool checked) {
 
 void MainWindow::on_autoPPDCheckBox_toggled(bool checked) {
     if (checked) {
-
-        if (!powerMonitor.connectToPowerProfiles()) {
-            if (!powerMonitor.connectToSystem76Power()) {
-                QMessageBox::critical(nullptr, this->windowTitle(), tr("Couldn't connect to a power profile service.\n"
-                                                                       "Make sure that Power Profiles Daemon, TuneD, or system76-power is installed and restart the system."));
-                ui->autoPPDCheckBox->setChecked(0);
-                return;
-            }
+        if (powerMonitor.connectToSystem76Power()) {
             powerMonitor.querySystem76Profile();
-        } else {
+        } else if (powerMonitor.connectToPowerProfiles()) {
             powerMonitor.queryPowerProfile();
+        } else {
+            QMessageBox::critical(nullptr, this->windowTitle(), tr("Couldn't connect to a power profile service.\n"
+                                                                   "Make sure that Power Profiles Daemon, TuneD, or system76-power is installed and restart the system."));
+            ui->autoPPDCheckBox->setChecked(0);
+            return;
         }
 
         powerMonitor.disconnectFromUpower();

--- a/src/powermonitor.cpp
+++ b/src/powermonitor.cpp
@@ -205,3 +205,78 @@ PowerProfile PowerMonitor::parsePowerProfile(const QString &profile) {
         return PowerProfile::PowerSaver;
     return PowerProfile::Unknown;
 }
+
+bool PowerMonitor::connectToSystem76Power() {
+    if(isSystem76Connected) {
+        return true;
+    }
+
+    auto bus = QDBusConnection::systemBus();
+
+    if (!bus.interface()->isServiceRegistered("com.system76.PowerDaemon")) {
+        return false;
+    }
+
+    bool ok = bus.connect(
+        "com.system76.PowerDaemon",
+        "/com/system76/PowerDaemon",
+        "com.system76.PowerDaemon",
+        "PowerProfileSwitch",
+        this,
+        SLOT(onSystem76ProfileChanged(QString))
+        );
+
+    isSystem76Connected = ok;
+    return ok;
+}
+
+void PowerMonitor::disconnectFromSystem76Power() {
+    if (isSystem76Connected) {
+        QDBusConnection::systemBus().disconnect(
+            "com.system76.PowerDaemon",
+            "/com/system76/PowerDaemon",
+            "com.system76.PowerDaemon",
+            "PowerProfileSwitch",
+            this,
+            SLOT(onSystem76ProfileChanged(QString))
+            );
+        isSystem76Connected = false;
+    }
+}
+
+void PowerMonitor::querySystem76Profile() {
+    if (isSystem76Connected) {
+        QDBusInterface iface(
+            "com.system76.PowerDaemon",
+            "/com/system76/PowerDaemon",
+            "com.system76.PowerDaemon",
+            QDBusConnection::systemBus()
+            );
+
+        QDBusReply<QString> reply = iface.call("GetProfile");
+
+        if (!reply.isValid()) {
+            return;
+        }
+
+        const QString profileName = reply.value();
+
+        PowerProfile profile = parseSystem76Profile(profileName);
+
+        emit currentPowerProfile(profile);
+    }
+}
+
+void PowerMonitor::onSystem76ProfileChanged(const QString &profile) {
+    emit currentPowerProfile(parseSystem76Profile(profile));
+}
+
+PowerProfile PowerMonitor::parseSystem76Profile(const QString &profile) {
+    if (profile == "Performance")
+        return PowerProfile::Performance;
+    if (profile == "Balanced")
+        return PowerProfile::Balanced;
+    if (profile == "Battery")
+        return PowerProfile::PowerSaver;
+    return PowerProfile::Unknown;
+}

--- a/src/powermonitor.h
+++ b/src/powermonitor.h
@@ -36,19 +36,24 @@ public:
 
     bool connectToUpower();
     bool connectToPowerProfiles();
+    bool connectToSystem76Power();
     void disconnectFromUpower();
     void disconnectFromPowerProfiles();
+    void disconnectFromSystem76Power();
     void queryChargerState();
     void queryPowerProfile();
+    void querySystem76Profile();
 
     Q_ENUM(PowerProfile)
 
 private:
     bool parseChargerState(uint state) const;
     PowerProfile parsePowerProfile(const QString &profile);
+    PowerProfile parseSystem76Profile(const QString &profile);
 
     bool isUPowerConnected = false;
     bool isPowerProfileConnected = false;
+    bool isSystem76Connected = false;
 
 signals:
     void currentChargerState(bool isOnline);
@@ -62,6 +67,8 @@ private slots:
     void onPowerProfileChanged(const QString &interface,
                                const QVariantMap &changed,
                                const QStringList &invalidatedProps);
+
+    void onSystem76ProfileChanged(const QString &profile);
 };
 
 #endif // POWERMONITOR_H


### PR DESCRIPTION
- Add system76-power daemon as a power profile backend for the "Follow system's power profile" feature
- system76-power is prioritized over PPD when both are available, falling back to PPD if system76-power is not found
- Complete pt_BR translation (80/80 strings)

Additionally, system76-power registers a PPD compatibility layer on D-Bus (`net.hadess.PowerProfiles`), which made `connectToPowerProfiles()` succeed — but the compatibility layer does not emit `PropertiesChanged` signals when the profile changes, so the shift mode was never updated. That's why I added native system76-power D-Bus integration via `com.system76.PowerDaemon` service, listening to the `PowerProfileSwitch` signal, then changed the connection priority: try system76-power first (native), then fall back to PPD

- Profile mapping: `Performance` → High Performance, `Balanced` → Balanced, `Battery` → Super Battery

## Changes

- `src/powermonitor.h` — Added system76-power methods and slot declarations
- `src/powermonitor.cpp` — Implemented connect/disconnect/query/signal handler/parser for system76-power
- `src/mainwindow.cpp` — Prioritize system76-power over PPD, added disconnect calls
- `src/i18n/MControlCenter_pt_BR.ts` — Completed pt_BR translation (80/80 strings)