### PR TITLE
Preserve advanced fan curve across AC/DC profile switches

### DIFF
--- a/src/operate.cpp
+++ b/src/operate.cpp
@@ -418,7 +418,11 @@ void Operate::setUserMode(user_mode userMode) const {
     }
     
     if (msiEcHelper.hasFanMode()) {
-        msiEcHelper.setFanMode(fanMode);
+        Settings s;
+        bool advancedActive = s.isValueExist(settingsGroup + "fanModeAdvanced") &&
+                              s.getValue(settingsGroup + "fanModeAdvanced").toBool();
+        if (!advancedActive)
+            msiEcHelper.setFanMode(fanMode);
     }
 
     if (msiEcHelper.hasSuperBattery()) {


### PR DESCRIPTION
## Problem

With `autoAcDcProfilesState=true` and `fanModeAdvanced=true`, every AC connect / disconnect — and the initial detection at MCC startup — triggers `on_ChargerStateChange()` → `setModeFromSelection()` → `setUserMode()`. Inside `setUserMode()`, `fanMode` is hardcoded to `auto_fan_mode` for every profile except Silent, and unconditionally written to the EC via `msiEcHelper.setFanMode()`.

This silently disables the user's custom fan curve. Externally observable as `fan_mode=auto` in `/sys/devices/platform/msi-ec/fan_mode` even when the GUI checkbox "Advanced fan control" is still ticked. The fan curve registers (e.g. 0x6A–0x78 on G2_10 devices) remain populated, but the EC is no longer in advanced mode to use them, so the fan reverts to the EC's built-in auto curve.

This was introduced by the Charger Detection + PPD Integration change (#307), because that is what wired up the auto `setUserMode()` call path on charger state changes.

## Fix

In `Operate::setUserMode()`, before pushing `fanMode`, check the persisted `fanModeAdvanced` setting. If the user has advanced fan control enabled, leave the EC's `fan_mode` alone — `shift_mode` and `super_battery` are still applied as before, so the rest of the profile transition still works. This preserves the user's intent across AC/DC and PPD-driven transitions.

No behavior change for users with `fanModeAdvanced=false`.

## Verified

Reproduced and fixed on MSI Raider 18 HX AI A2XWJG (MS-1824), EC firmware `1824EMS1.108`, kernel 6.17.0-29, msi-ec 0.13:

- Before patch: launch MCC on AC → `fan_mode` flips from `advanced` to `auto` within ~1 s of startup. Plug/unplug AC reproduces it on demand.
- After patch: `fan_mode=advanced` is preserved across MCC start, AC connect/disconnect, and PPD mode changes. `shift_mode` continues to follow the selected profile. The EC fan curve registers drive the fans as the user configured.