### PR TITLE
Fix power profile synchronization and add one-click scripts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -e
+
+# Check if running as root
+if [ "$EUID" -ne 0 ]; then
+  echo "Please run this script with sudo:"
+  echo "  sudo $0"
+  exit 1
+fi
+
+# Get the directory of this script
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR"
+
+echo "=== Building MControlCenter ==="
+if [ -n "$SUDO_USER" ]; then
+    # Run build as the original user to keep file ownership correct
+    sudo -u "$SUDO_USER" mkdir -p build
+    sudo -u "$SUDO_USER" sh -c "cd build && cmake .. && make -j$(nproc)"
+else
+    mkdir -p build
+    cd build
+    cmake ..
+    make -j$(nproc)
+    cd ..
+fi
+
+echo "=== Installing MControlCenter ==="
+BIN_PATH='/usr/bin/'
+LIB_EXEC_PATH='/usr/libexec/'
+SCALABLE_ICONS_PATH='/usr/share/icons/hicolor/scalable/apps/'
+SHORTCUTS_PATH='/usr/share/applications/'
+DBUS_SYSTEM_PATH='/usr/share/dbus-1/system.d/'
+DBUS_SERVICES_PATH='/usr/share/dbus-1/system-services/'
+
+# Copy binaries
+install -vDm755 build/mcontrolcenter "$BIN_PATH"mcontrolcenter
+install -vDm755 build/helper/mcontrolcenter-helper "$LIB_EXEC_PATH"mcontrolcenter-helper
+
+# Icons & Shortcuts
+install -vDm644 resources/mcontrolcenter.desktop "$SHORTCUTS_PATH"mcontrolcenter.desktop
+install -vDm644 resources/mcontrolcenter.svg "$SCALABLE_ICONS_PATH"mcontrolcenter.svg
+
+# D-Bus configuration
+install -vDm644 src/helper/mcontrolcenter-helper.conf "$DBUS_SYSTEM_PATH"mcontrolcenter-helper.conf
+install -vDm644 src/helper/mcontrolcenter.helper.service "$DBUS_SERVICES_PATH"mcontrolcenter.helper.service
+
+# Clean up local user shortcuts if any
+if [ -n "$SUDO_USER" ]; then
+    rm -fv "/home/$SUDO_USER/.local/share/applications/mcontrolcenter.desktop"
+fi
+
+# Restart helper service
+echo "=== Restarting helper service ==="
+killall mcontrolcenter-helper 2>/dev/null || true
+
+echo "=== Installation successful! ==="

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -29,15 +29,20 @@
 
 QByteArray ecData;
 
-Helper::Helper() {
+Helper::Helper() : iface(nullptr) {}
+
+void Helper::init() const {
+    if (iface) return;
     if (!QDBusConnection::systemBus().isConnected()) {
-        fprintf(stderr, "Cannot connect to the D-Bus system bus");
+        fprintf(stderr, "Cannot connect to the D-Bus system bus\n");
         return;
     }
     iface = new QDBusInterface(SERVICE_NAME, "/", INTERFACE_NAME, QDBusConnection::systemBus());
 }
 
 bool Helper::isEcSysModuleLoaded() {
+    init();
+    if (!iface) return false;
     if (QDBusReply<bool> reply = iface->call("isEcSysModuleLoaded"); reply.isValid())
         return reply.value();
     printError(iface->lastError());
@@ -45,6 +50,8 @@ bool Helper::isEcSysModuleLoaded() {
 }
 
 bool Helper::loadEcSysModule() {
+    init();
+    if (!iface) return false;
     if (QDBusReply<bool> reply = iface->call("loadEcSysModule"); reply.isValid())
         return reply.value();
     printError(iface->lastError());
@@ -52,6 +59,8 @@ bool Helper::loadEcSysModule() {
 }
 
 bool Helper::updateData() {
+    init();
+    if (!iface) return false;
     if (QDBusReply<QByteArray> reply = iface->call("getData"); reply.isValid() &&
                                                                reply.value().size() == EC_SPACE_SIZE) {
         ecData = reply.value();
@@ -62,6 +71,8 @@ bool Helper::updateData() {
 }
 
 void Helper::updateDataAsync() {
+    init();
+    if (!iface) return;
     QDBusPendingCall async = iface->asyncCall("getData");
     QDBusPendingCallWatcher const *watcher = new QDBusPendingCallWatcher(async, this);
 
@@ -95,6 +106,8 @@ QByteArray Helper::getValues(int startAddress, int size) const {
 }
 
 void Helper::putValue(int address, int value) {
+    init();
+    if (!iface) return;
     if (getValue(address) == value)
         return;
     iface->call("putValue", address, value);
@@ -102,6 +115,8 @@ void Helper::putValue(int address, int value) {
 }
 
 void Helper::quit() {
+    init();
+    if (!iface) return;
     iface->call("quit");
     printError(iface->lastError());
 }

--- a/src/helper.h
+++ b/src/helper.h
@@ -28,6 +28,7 @@ class Helper : public QObject {
 Q_OBJECT
 public:
     Helper();
+    void init() const;
 
     bool isEcSysModuleLoaded();
     bool loadEcSysModule();
@@ -38,7 +39,7 @@ public:
     QByteArray getValues(int startAddress, int size) const;
     void putValue(int address, int value);
     void quit();
-    QDBusInterface *iface;
+    mutable QDBusInterface *iface;
 private:
     void printError(QDBusError const & error) const;
 private slots:

--- a/src/helper/msi-ec.cpp
+++ b/src/helper/msi-ec.cpp
@@ -308,3 +308,25 @@ int MsiEc::getKeyboardBacklightBrightness() const {
 void MsiEc::setKeyboardBacklightBrightness(int value) const {
     writeFile(msi_ec_kbd_backlight_brightness, QString::number(value));
 }
+
+QVariantMap MsiEc::getRealtimeData() const {
+    QVariantMap map;
+    if (hasWebcam()) map["webcam"] = getWebcam();
+    if (hasWebcamBlock()) map["webcam_block"] = getWebcamBlock();
+    if (hasFnWinSwap()) map["fn_win_swap"] = getFnWinSwap();
+    if (hasCoolerBoost()) map["cooler_boost"] = getCoolerBoost();
+    if (hasShiftMode()) map["shift_mode"] = getShiftMode();
+    if (hasSuperBattery()) map["super_battery"] = getSuperBattery();
+    if (hasFanMode()) map["fan_mode"] = getFanMode();
+    if (hasCPURealtimeTemperature()) map["cpu_temp"] = getCPURealtimeTemperature();
+    if (hasCPURealtimeFanSpeed()) map["cpu_fan_speed"] = getCPURealtimeFanSpeed();
+    if (hasCPUBasicFanSpeed()) map["cpu_basic_fan_speed"] = getCPUBasicFanSpeed();
+    if (hasGPURealtimeTemperature()) map["gpu_temp"] = getGPURealtimeTemperature();
+    if (hasGPURealtimeFanSpeed()) map["gpu_fan_speed"] = getGPURealtimeFanSpeed();
+    if (hasBatteryStartThreshold()) map["battery_start_threshold"] = getBatteryStartThreshold();
+    if (hasBatteryEndThreshold()) map["battery_end_threshold"] = getBatteryEndThreshold();
+    if (hasBatteryCapacity()) map["battery_capacity"] = getBatteryCapacity();
+    if (hasBatteryStatus()) map["battery_status"] = getBatteryStatus();
+    if (hasKeyboardBacklightBrightness()) map["keyboard_brightness"] = getKeyboardBacklightBrightness();
+    return map;
+}

--- a/src/helper/msi-ec.h
+++ b/src/helper/msi-ec.h
@@ -24,6 +24,7 @@
 #include <QtCore/QObject>
 #include <QtDBus/QDBusAbstractAdaptor>
 #include <QtDBus/QDBusVariant>
+#include <QVariantMap>
 
 /**
  * Interface for [msi-ec by BeardOverflow](https://github.com/BeardOverflow/msi-ec/)
@@ -133,6 +134,8 @@ public slots:
     [[nodiscard]] bool hasKeyboardBacklightBrightness() const;
     [[nodiscard]] int getKeyboardBacklightBrightness() const;
     Q_NOREPLY void setKeyboardBacklightBrightness(int value) const;
+
+    [[nodiscard]] QVariantMap getRealtimeData() const;
 };
 
 #endif // MSI_EC_H

--- a/src/i18n/MControlCenter_de_DE.ts
+++ b/src/i18n/MControlCenter_de_DE.ts
@@ -156,6 +156,16 @@
         <translation>Erweitert</translation>
     </message>
     <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to Power Profiles Daemon.
+Make sure that either Power Profiles Daemon or TuneD is installed and restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cooling</source>
         <translation>Kühlen</translation>
     </message>
@@ -214,6 +224,22 @@
     <message>
         <source>Current fan Mode:</source>
         <translation>Aktueller Lüftermodus:</translation>
+    </message>
+    <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Keyboard</source>

--- a/src/i18n/MControlCenter_en.ts
+++ b/src/i18n/MControlCenter_en.ts
@@ -116,16 +116,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Couldn&apos;t connect to UPower to get charger status.
-Make sure that UPower is installed and running then restart the app.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Couldn&apos;t connect to Power Profiles Daemon.
-Make sure that either Power Profiles Daemon or TuneD is installed and restart the app.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -163,6 +153,16 @@ Make sure that either Power Profiles Daemon or TuneD is installed and restart th
     </message>
     <message>
         <source>Advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to Power Profiles Daemon.
+Make sure that either Power Profiles Daemon or TuneD is installed and restart the system.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/MControlCenter_es.ts
+++ b/src/i18n/MControlCenter_es.ts
@@ -156,6 +156,16 @@
         <translation>Avanzado</translation>
     </message>
     <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to Power Profiles Daemon.
+Make sure that either Power Profiles Daemon or TuneD is installed and restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cooling</source>
         <translation>Enfriamiento</translation>
     </message>
@@ -244,7 +254,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>If you mainly use your laptop with the charger plugged most of the time, it is recommended to set the charge capacity at a lower percentage (60% or 80%) to prolong your battery lifecycle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/MControlCenter_eu.ts
+++ b/src/i18n/MControlCenter_eu.ts
@@ -156,6 +156,16 @@
         <translation>Aurreratua</translation>
     </message>
     <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to Power Profiles Daemon.
+Make sure that either Power Profiles Daemon or TuneD is installed and restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cooling</source>
         <translation>Hoztu</translation>
     </message>
@@ -244,7 +254,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>If you mainly use your laptop with the charger plugged most of the time, it is recommended to set the charge capacity at a lower percentage (60% or 80%) to prolong your battery lifecycle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/MControlCenter_fi_FI.ts
+++ b/src/i18n/MControlCenter_fi_FI.ts
@@ -156,6 +156,16 @@
         <translation>Edistynyt</translation>
     </message>
     <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to Power Profiles Daemon.
+Make sure that either Power Profiles Daemon or TuneD is installed and restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cooling</source>
         <translation>Jäähdytys</translation>
     </message>
@@ -244,7 +254,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>If you mainly use your laptop with the charger plugged most of the time, it is recommended to set the charge capacity at a lower percentage (60% or 80%) to prolong your battery lifecycle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/MControlCenter_fr.ts
+++ b/src/i18n/MControlCenter_fr.ts
@@ -156,6 +156,16 @@
         <translation>Avancé</translation>
     </message>
     <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to Power Profiles Daemon.
+Make sure that either Power Profiles Daemon or TuneD is installed and restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cooling</source>
         <translation>Refroidissement</translation>
     </message>
@@ -244,8 +254,24 @@
         <translation>Performances maximales au prix de la chaleur et d&apos;une consommation électrique accrue</translation>
     </message>
     <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>If you mainly use your laptop with the charger plugged most of the time, it is recommended to set the charge capacity at a lower percentage (60% or 80%) to prolong your battery lifecycle.</source>
         <translation>Si vous utilisez principalement votre ordinateur avec le chargeur branché, il est recommandé de mettre la limite de charge à un pourcentage plus bas (60&#xa0;% ou 80&#xa0;%) pour prolonger la durée de vie de votre batterie.</translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charge the battery when under 90%, stop at 100%</source>

--- a/src/i18n/MControlCenter_hu.ts
+++ b/src/i18n/MControlCenter_hu.ts
@@ -156,6 +156,16 @@
         <translation>Haladó</translation>
     </message>
     <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to Power Profiles Daemon.
+Make sure that either Power Profiles Daemon or TuneD is installed and restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cooling</source>
         <translation>Hűtés</translation>
     </message>
@@ -244,7 +254,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>If you mainly use your laptop with the charger plugged most of the time, it is recommended to set the charge capacity at a lower percentage (60% or 80%) to prolong your battery lifecycle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/MControlCenter_it.ts
+++ b/src/i18n/MControlCenter_it.ts
@@ -156,6 +156,16 @@
         <translation>Avanzato</translation>
     </message>
     <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to Power Profiles Daemon.
+Make sure that either Power Profiles Daemon or TuneD is installed and restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cooling</source>
         <translation>Raffreddamento</translation>
     </message>
@@ -244,7 +254,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>If you mainly use your laptop with the charger plugged most of the time, it is recommended to set the charge capacity at a lower percentage (60% or 80%) to prolong your battery lifecycle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/MControlCenter_nb.ts
+++ b/src/i18n/MControlCenter_nb.ts
@@ -156,6 +156,16 @@
         <translation>Avansert</translation>
     </message>
     <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to Power Profiles Daemon.
+Make sure that either Power Profiles Daemon or TuneD is installed and restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cooling</source>
         <translation>Kjøling</translation>
     </message>
@@ -244,7 +254,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>If you mainly use your laptop with the charger plugged most of the time, it is recommended to set the charge capacity at a lower percentage (60% or 80%) to prolong your battery lifecycle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/MControlCenter_nl_NL.ts
+++ b/src/i18n/MControlCenter_nl_NL.ts
@@ -156,6 +156,16 @@
         <translation>Geavanceerd</translation>
     </message>
     <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to Power Profiles Daemon.
+Make sure that either Power Profiles Daemon or TuneD is installed and restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cooling</source>
         <translation>Koelen</translation>
     </message>
@@ -244,7 +254,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>If you mainly use your laptop with the charger plugged most of the time, it is recommended to set the charge capacity at a lower percentage (60% or 80%) to prolong your battery lifecycle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/MControlCenter_pt_BR.ts
+++ b/src/i18n/MControlCenter_pt_BR.ts
@@ -156,6 +156,16 @@
         <translation>Avançado</translation>
     </message>
     <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to Power Profiles Daemon.
+Make sure that either Power Profiles Daemon or TuneD is installed and restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cooling</source>
         <translation>Arrefecimento</translation>
     </message>
@@ -244,7 +254,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>If you mainly use your laptop with the charger plugged most of the time, it is recommended to set the charge capacity at a lower percentage (60% or 80%) to prolong your battery lifecycle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/MControlCenter_pt_PT.ts
+++ b/src/i18n/MControlCenter_pt_PT.ts
@@ -156,6 +156,16 @@
         <translation>Avançado</translation>
     </message>
     <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to Power Profiles Daemon.
+Make sure that either Power Profiles Daemon or TuneD is installed and restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cooling</source>
         <translation>Arrefecimento</translation>
     </message>
@@ -244,7 +254,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>If you mainly use your laptop with the charger plugged most of the time, it is recommended to set the charge capacity at a lower percentage (60% or 80%) to prolong your battery lifecycle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/MControlCenter_ru.ts
+++ b/src/i18n/MControlCenter_ru.ts
@@ -156,6 +156,16 @@
         <translation>Расширенный</translation>
     </message>
     <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to Power Profiles Daemon.
+Make sure that either Power Profiles Daemon or TuneD is installed and restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cooling</source>
         <translation>Охлаждение</translation>
     </message>
@@ -214,6 +224,22 @@
     <message>
         <source>Current fan Mode:</source>
         <translation>Режим вентилятора:</translation>
+    </message>
+    <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Keyboard</source>

--- a/src/i18n/MControlCenter_tr.ts
+++ b/src/i18n/MControlCenter_tr.ts
@@ -159,6 +159,16 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to Power Profiles Daemon.
+Make sure that either Power Profiles Daemon or TuneD is installed and restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cooling</source>
         <translation type="unfinished"></translation>
     </message>
@@ -247,7 +257,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>If you mainly use your laptop with the charger plugged most of the time, it is recommended to set the charge capacity at a lower percentage (60% or 80%) to prolong your battery lifecycle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/MControlCenter_vi.ts
+++ b/src/i18n/MControlCenter_vi.ts
@@ -156,6 +156,16 @@
         <translation>Nâng cao</translation>
     </message>
     <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to Power Profiles Daemon.
+Make sure that either Power Profiles Daemon or TuneD is installed and restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cooling</source>
         <translation>Tản nhiệt</translation>
     </message>
@@ -244,7 +254,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>If you mainly use your laptop with the charger plugged most of the time, it is recommended to set the charge capacity at a lower percentage (60% or 80%) to prolong your battery lifecycle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/MControlCenter_zh_CN.ts
+++ b/src/i18n/MControlCenter_zh_CN.ts
@@ -156,6 +156,16 @@
         <translation>高级（手动）</translation>
     </message>
     <message>
+        <source>Couldn&apos;t connect to UPower to get charger status.
+Make sure that UPower is installed and running then restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t connect to Power Profiles Daemon.
+Make sure that either Power Profiles Daemon or TuneD is installed and restart the system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cooling</source>
         <translation>冷却选项</translation>
     </message>
@@ -244,7 +254,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Follow system&apos;s power profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>If you mainly use your laptop with the charger plugged most of the time, it is recommended to set the charge capacity at a lower percentage (60% or 80%) to prolong your battery lifecycle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic Profile Switching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Charger:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On Battery:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,11 +17,33 @@
  */
 
 #include "mainwindow.h"
+#include "operate.h"
 #include <QApplication>
 #include <QTranslator>
 #include <QDBusConnectionInterface>
+#include <iostream>
 
 int main(int argc, char *argv[]) {
+    if (argc > 1 && strcmp(argv[1], "--test") == 0) {
+        QCoreApplication a(argc, argv);
+        Operate op;
+        op.doProbe();
+        op.updateEcData(); // Synchronous update
+        
+        std::cout << "--- MControlCenter Test Stats ---" << std::endl;
+        std::cout << "msi-ec loaded: " << op.isMsiEcLoaded() << std::endl;
+        std::cout << "ec_sys loaded: " << op.isEcSysModuleLoaded() << std::endl;
+        std::cout << "CPU Temp: " << op.getCpuTemp() << " C" << std::endl;
+        auto gpuTemp = op.getGpuTemp();
+        std::cout << "GPU Temp: " << (gpuTemp.has_value() ? gpuTemp.value() : -1) << " C" << std::endl;
+        std::cout << "Fan 1 Speed: " << op.getFan1Speed() << " RPM" << std::endl;
+        auto fan2 = op.getFan2Speed();
+        std::cout << "Fan 2 Speed: " << (fan2.has_value() ? fan2.value() : -1) << " RPM" << std::endl;
+        std::cout << "Battery Charge: " << op.getBatteryCharge() << "%" << std::endl;
+        std::cout << "Webcam active: " << op.getWebCamState() << std::endl;
+        return 0;
+    }
+
     const QString serviceName = "io.github.dmitry_s93.MControlCenter";
 
     if (QDBusConnection::sessionBus().interface()->isServiceRegistered(serviceName)) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -430,21 +430,30 @@ void MainWindow::updateCoolerBoostState() const {
 
 void MainWindow::updateUserMode() {
     if (operate.updateEcData()) {
+        ui->balancedModeRadioButton->blockSignals(true);
+        ui->highPerformanceModeRadioButton->blockSignals(true);
+        ui->silentModeRadioButton->blockSignals(true);
+        ui->superBatteryModeRadioButton->blockSignals(true);
+        balancedMode->blockSignals(true);
+        highPerformanceMode->blockSignals(true);
+        silentMode->blockSignals(true);
+        superBatteryMode->blockSignals(true);
+
         switch (operate.getUserMode()) {
             case user_mode::balanced_mode:
-                ui->balancedModeRadioButton->click();
+                ui->balancedModeRadioButton->setChecked(true);
                 balancedMode->setChecked(true);
                 break;
             case user_mode::performance_mode:
-                ui->highPerformanceModeRadioButton->click();
+                ui->highPerformanceModeRadioButton->setChecked(true);
                 highPerformanceMode->setChecked(true);
                 break;
             case user_mode::silent_mode:
-                ui->silentModeRadioButton->click();
+                ui->silentModeRadioButton->setChecked(true);
                 silentMode->setChecked(true);
                 break;
             case user_mode::super_battery_mode:
-                ui->superBatteryModeRadioButton->click();
+                ui->superBatteryModeRadioButton->setChecked(true);
                 superBatteryMode->setChecked(true);
                 break;
             case user_mode::unknown_mode:
@@ -462,6 +471,15 @@ void MainWindow::updateUserMode() {
                 }
                 break;
         }
+
+        ui->balancedModeRadioButton->blockSignals(false);
+        ui->highPerformanceModeRadioButton->blockSignals(false);
+        ui->silentModeRadioButton->blockSignals(false);
+        ui->superBatteryModeRadioButton->blockSignals(false);
+        balancedMode->blockSignals(false);
+        highPerformanceMode->blockSignals(false);
+        silentMode->blockSignals(false);
+        superBatteryMode->blockSignals(false);
     }
 }
 
@@ -548,21 +566,33 @@ void MainWindow::setBestBattery() {
 void MainWindow::setHighPerformanceMode() {
     operate.setUserMode(user_mode::performance_mode);
     updateUserMode();
+    if (ui->autoPPDCheckBox->isChecked()) {
+        powerMonitor.setPowerProfile(PowerProfile::Performance);
+    }
 }
 
 void MainWindow::setBalancedMode() {
     operate.setUserMode(user_mode::balanced_mode);
     updateUserMode();
+    if (ui->autoPPDCheckBox->isChecked()) {
+        powerMonitor.setPowerProfile(PowerProfile::Balanced);
+    }
 }
 
 void MainWindow::setSilentMode() {
     operate.setUserMode(user_mode::silent_mode);
     updateUserMode();
+    if (ui->autoPPDCheckBox->isChecked()) {
+        powerMonitor.setPowerProfile(PowerProfile::PowerSaver);
+    }
 }
 
 void MainWindow::setSuperBatteryMode() {
     operate.setUserMode(user_mode::super_battery_mode);
     updateUserMode();
+    if (ui->autoPPDCheckBox->isChecked()) {
+        powerMonitor.setPowerProfile(PowerProfile::PowerSaver);
+    }
 }
 
 void MainWindow::setCoolerBoostState(bool enabled) const {
@@ -735,10 +765,22 @@ void MainWindow::on_PowerProfileChange(const PowerProfile profile) {
             setBalancedMode();
             ui->balancedModeRadioButton->setChecked(true);
             break;
-        case PowerProfile::PowerSaver:
-            setSuperBatteryMode();
-            ui->superBatteryModeRadioButton->setChecked(true);
+        case PowerProfile::PowerSaver: {
+            user_mode currentMode = operate.getUserMode();
+            if (currentMode != user_mode::silent_mode && currentMode != user_mode::super_battery_mode) {
+                setSuperBatteryMode();
+                ui->superBatteryModeRadioButton->setChecked(true);
+            } else {
+                if (currentMode == user_mode::silent_mode) {
+                    ui->silentModeRadioButton->setChecked(true);
+                    if (silentMode) silentMode->setChecked(true);
+                } else {
+                    ui->superBatteryModeRadioButton->setChecked(true);
+                    if (superBatteryMode) superBatteryMode->setChecked(true);
+                }
+            }
             break;
+        }
         case PowerProfile::Unknown:
             default:;
         }
@@ -865,10 +907,6 @@ void MainWindow::on_autoPPDCheckBox_toggled(bool checked) {
         }
 
         powerMonitor.disconnectFromUpower();
-        ui->highPerformanceModeRadioButton->setEnabled(0);
-        ui->balancedModeRadioButton->setEnabled(0);
-        ui->silentModeRadioButton->setEnabled(0);
-        ui->superBatteryModeRadioButton->setEnabled(0);
         ui->autoAcDcProfilesGroupBox->setChecked(0);
         ui->autoAcDcProfilesGroupBox->setEnabled(0);
         powerMonitor.queryPowerProfile();

--- a/src/msi-ec_helper.cpp
+++ b/src/msi-ec_helper.cpp
@@ -22,9 +22,12 @@
 
 #include <QDBusReply>
 
-MsiEcHelper::MsiEcHelper() {
+MsiEcHelper::MsiEcHelper() : iface(nullptr) {}
+
+void MsiEcHelper::init() const {
+    if (iface) return;
     if (!QDBusConnection::systemBus().isConnected()) {
-        fprintf(stderr, "Cannot connect to the D-Bus system bus");
+        fprintf(stderr, "Cannot connect to the D-Bus system bus\n");
         return;
     }
     iface = new QDBusInterface(SERVICE_NAME, "/msi_ec", INTERFACE_NAME_MSI_EC, QDBusConnection::systemBus());
@@ -343,6 +346,38 @@ void MsiEcHelper::setKeyboardBacklightBrightness(int value) const {
     return setValue<int>("setKeyboardBacklightBrightness", value);
 }
 
+bool MsiEcHelper::updateData() {
+    init();
+    if (!iface) return false;
+    QDBusReply<QVariantMap> reply = iface->call("getRealtimeData");
+    if (reply.isValid()) {
+        m_realtimeData = reply.value();
+        return true;
+    }
+    printError(iface->lastError());
+    return false;
+}
+
+void MsiEcHelper::updateDataAsync() {
+    init();
+    if (!iface) return;
+    QDBusPendingCall async = iface->asyncCall("getRealtimeData");
+    QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(async, this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, &MsiEcHelper::callFinishedSlot);
+}
+
+void MsiEcHelper::callFinishedSlot(QDBusPendingCallWatcher *call) {
+    QDBusPendingReply<QVariantMap> reply = *call;
+    if (reply.isError()) {
+        printError(reply.error());
+        MainWindow::setUpdateDataError(true);
+    } else {
+        m_realtimeData = reply.value();
+        MainWindow::setUpdateDataError(false);
+    }
+    call->deleteLater();
+}
+
 ////////////////////////////////
 
 void MsiEcHelper::printError(QDBusError const &error) const {
@@ -352,6 +387,8 @@ void MsiEcHelper::printError(QDBusError const &error) const {
 
 template <typename T>
 inline std::optional<T> MsiEcHelper::getOptionalValue(QString method) const {
+    init();
+    if (!iface) return std::nullopt;
     if (QDBusReply<T> reply = iface->call(method); reply.isValid())
         return reply.value();
     printError(iface->lastError());
@@ -360,11 +397,65 @@ inline std::optional<T> MsiEcHelper::getOptionalValue(QString method) const {
 
 template <typename T>
 inline T MsiEcHelper::getValue(QString method, T defaultValue) const {
+    if (method.startsWith("has") || method.startsWith("is") || method.startsWith("getAvailable") || method.startsWith("getFW")) {
+        if (!m_cache.contains(method)) {
+            auto val = getOptionalValue<T>(method);
+            if (val.has_value()) {
+                m_cache[method] = val.value();
+            } else {
+                return defaultValue;
+            }
+        }
+        return m_cache[method].value<T>();
+    }
+
+    QString key;
+    if (method == "getWebcam") key = "webcam";
+    else if (method == "getWebcamBlock") key = "webcam_block";
+    else if (method == "getFnWinSwap") key = "fn_win_swap";
+    else if (method == "getCoolerBoost") key = "cooler_boost";
+    else if (method == "getShiftMode") key = "shift_mode";
+    else if (method == "getSuperBattery") key = "super_battery";
+    else if (method == "getFanMode") key = "fan_mode";
+    else if (method == "getCPURealtimeTemperature") key = "cpu_temp";
+    else if (method == "getCPURealtimeFanSpeed") key = "cpu_fan_speed";
+    else if (method == "getCPUBasicFanSpeed") key = "cpu_basic_fan_speed";
+    else if (method == "getGPURealtimeTemperature") key = "gpu_temp";
+    else if (method == "getGPURealtimeFanSpeed") key = "gpu_fan_speed";
+    else if (method == "getBatteryStartThreshold") key = "battery_start_threshold";
+    else if (method == "getBatteryEndThreshold") key = "battery_end_threshold";
+    else if (method == "getBatteryCapacity") key = "battery_capacity";
+    else if (method == "getBatteryStatus") key = "battery_status";
+    else if (method == "getKeyboardBacklightBrightness") key = "keyboard_brightness";
+
+    if (!key.isEmpty() && m_realtimeData.contains(key)) {
+        return m_realtimeData[key].value<T>();
+    }
+
     return getOptionalValue<T>(method).value_or(defaultValue);
 }
 
 template <typename T>
 void MsiEcHelper::setValue(QString method, T value) const {
+    init();
+    if (!iface) return;
     iface->call(method, value);
     printError(iface->lastError());
+
+    QString key;
+    if (method == "setWebcam") key = "webcam";
+    else if (method == "setWebcamBlock") key = "webcam_block";
+    else if (method == "setFnWinSwap") key = "fn_win_swap";
+    else if (method == "setCoolerBoost") key = "cooler_boost";
+    else if (method == "setShiftMode") key = "shift_mode";
+    else if (method == "setSuperBattery") key = "super_battery";
+    else if (method == "setFanMode") key = "fan_mode";
+    else if (method == "setCPUBasicFanSpeed") key = "cpu_basic_fan_speed";
+    else if (method == "setBatteryStartThreshold") key = "battery_start_threshold";
+    else if (method == "setBatteryEndThreshold") key = "battery_end_threshold";
+    else if (method == "setKeyboardBacklightBrightness") key = "keyboard_brightness";
+
+    if (!key.isEmpty()) {
+        const_cast<MsiEcHelper*>(this)->m_realtimeData[key] = QVariant::fromValue(value);
+    }
 }

--- a/src/msi-ec_helper.h
+++ b/src/msi-ec_helper.h
@@ -22,11 +22,16 @@
 #include "operate.h"
 #include <QtCore/QObject>
 #include <QtDBus/QDBusInterface>
+#include <QtDBus/QDBusPendingCallWatcher>
+#include <QVariantMap>
 
 class MsiEcHelper : public QObject {
     Q_OBJECT
 public:
     MsiEcHelper();
+
+    bool updateData();
+    void updateDataAsync();
 
     [[nodiscard]] bool isMsiEcModuleLoaded();
 
@@ -113,9 +118,16 @@ public:
     [[nodiscard]] int getKeyboardBacklightBrightness() const;
     Q_NOREPLY void setKeyboardBacklightBrightness(int value) const;
 
+private slots:
+    void callFinishedSlot(QDBusPendingCallWatcher *call);
+
 private:
-    QDBusInterface *iface;
+    void init() const;
+    mutable QDBusInterface *iface;
     void printError(QDBusError const &error) const;
+
+    mutable QVariantMap m_cache;
+    mutable QVariantMap m_realtimeData;
 
     template <typename T>
     [[nodiscard]] std::optional<T> getOptionalValue(QString method) const;

--- a/src/operate.cpp
+++ b/src/operate.cpp
@@ -92,11 +92,19 @@ bool Operate::loadEcSysModule() const {
 }
 
 bool Operate::updateEcData() const {
-    return helper.updateData();
+    bool res1 = helper.updateData();
+    bool res2 = true;
+    if (msiEcHelper.isMsiEcModuleLoaded()) {
+        res2 = msiEcHelper.updateData();
+    }
+    return res1 && res2;
 }
 
 void Operate::updateEcDataAsync() const {
     helper.updateDataAsync();
+    if (msiEcHelper.isMsiEcModuleLoaded()) {
+        msiEcHelper.updateDataAsync();
+    }
 }
 
 bool Operate::doProbe() const {
@@ -522,7 +530,10 @@ bool Operate::isWebCamOffSupport() const {
 void Operate::loadSettings() const {
     Settings s;
 
-    if (getUserMode() != user_mode::unknown_mode && s.isValueExist(settingsGroup + "UserMode")) {
+    bool autoPPD = s.getValue(settingsGroup + "autoPPDstate").toBool();
+    bool autoAcDc = s.getValue(settingsGroup + "autoAcDcProfilesState").toBool();
+
+    if (!autoPPD && !autoAcDc && getUserMode() != user_mode::unknown_mode && s.isValueExist(settingsGroup + "UserMode")) {
         QString value = s.getValue(settingsGroup + "UserMode").toString();
         if (value == "balanced_mode")
             setUserMode(user_mode::balanced_mode);

--- a/src/powermonitor.cpp
+++ b/src/powermonitor.cpp
@@ -18,6 +18,7 @@
 
 #include "powermonitor.h"
 #include <QDBusInterface>
+#include <QDBusVariant>
 #include <qdbusconnectioninterface.h>
 
 PowerMonitor::PowerMonitor() = default;
@@ -34,7 +35,7 @@ bool PowerMonitor::connectToUpower() {
     }
 
     bool ok = bus.connect(
-        "org.freedesktop.UPower",
+        "",
         "/org/freedesktop/UPower/devices/DisplayDevice",
         "org.freedesktop.DBus.Properties",
         "PropertiesChanged",
@@ -48,7 +49,7 @@ bool PowerMonitor::connectToUpower() {
 void PowerMonitor::disconnectFromUpower() {
     if(isUPowerConnected) {
         QDBusConnection::systemBus().disconnect(
-            "org.freedesktop.UPower",
+            "",
             "/org/freedesktop/UPower/devices/DisplayDevice",
             "org.freedesktop.DBus.Properties",
             "PropertiesChanged",
@@ -64,18 +65,17 @@ void PowerMonitor::queryChargerState() {
         QDBusInterface iface(
             "org.freedesktop.UPower",
             "/org/freedesktop/UPower/devices/DisplayDevice",
-            "org.freedesktop.DBus.Properties",
+            "org.freedesktop.UPower.Device",
             QDBusConnection::systemBus()
             );
 
-        QDBusReply<QVariant> reply =
-            iface.call("Get", "org.freedesktop.UPower.Device", "State");
-
-        if (!reply.isValid()) {
-            return;
+        QVariant val = iface.property("State");
+        uint state = 0;
+        if (val.canConvert<QDBusVariant>()) {
+            state = val.value<QDBusVariant>().variant().toUInt();
+        } else {
+            state = val.toUInt();
         }
-
-        uint state = reply.value().toUInt();
         bool connected = parseChargerState(state);
 
         emit currentChargerState(connected);
@@ -94,7 +94,13 @@ void PowerMonitor::onChargerStateChanged(
     if (!changedProps.contains("State"))
         return;
 
-    uint state = changedProps.value("State").toUInt();
+    QVariant val = changedProps.value("State");
+    uint state = 0;
+    if (val.canConvert<QDBusVariant>()) {
+        state = val.value<QDBusVariant>().variant().toUInt();
+    } else {
+        state = val.toUInt();
+    }
     bool connected = parseChargerState(state);
 
     emit currentChargerState(connected);
@@ -127,7 +133,7 @@ bool PowerMonitor::connectToPowerProfiles() {
     }
 
     bool ok = bus.connect(
-        "net.hadess.PowerProfiles",
+        "",
         "/org/freedesktop/UPower/PowerProfiles",
         "org.freedesktop.DBus.Properties",
         "PropertiesChanged",
@@ -142,7 +148,7 @@ bool PowerMonitor::connectToPowerProfiles() {
 void PowerMonitor::disconnectFromPowerProfiles() {
     if (isPowerProfileConnected) {
         QDBusConnection::systemBus().disconnect(
-            "net.hadess.PowerProfiles",
+            "",
             "/org/freedesktop/UPower/PowerProfiles",
             "org.freedesktop.DBus.Properties",
             "PropertiesChanged",
@@ -158,20 +164,20 @@ void PowerMonitor::queryPowerProfile() {
         QDBusInterface iface(
             "net.hadess.PowerProfiles",
             "/org/freedesktop/UPower/PowerProfiles",
-            "org.freedesktop.DBus.Properties",
+            "org.freedesktop.UPower.PowerProfiles",
             QDBusConnection::systemBus()
             );
 
-        QDBusReply<QVariant> reply =
-            iface.call("Get", "org.freedesktop.UPower.PowerProfiles", "ActiveProfile");
-
-        if (!reply.isValid()) {
-            return;
+        QVariant val = iface.property("ActiveProfile");
+        QString ProfileName;
+        if (val.canConvert<QDBusVariant>()) {
+            ProfileName = val.value<QDBusVariant>().variant().toString();
+        } else {
+            ProfileName = val.toString();
         }
 
-        const QString ProfileName = reply.value().toString();
-
         PowerProfile profile = parsePowerProfile(ProfileName);
+        m_currentProfile = profile;
 
         emit currentPowerProfile(profile);
     }
@@ -189,9 +195,16 @@ void PowerMonitor::onPowerProfileChanged(
     if (!changed.contains("ActiveProfile"))
         return;
 
-    const QString ProfileName = changed.value("ActiveProfile").toString();
+    QVariant val = changed.value("ActiveProfile");
+    QString ProfileName;
+    if (val.canConvert<QDBusVariant>()) {
+        ProfileName = val.value<QDBusVariant>().variant().toString();
+    } else {
+        ProfileName = val.toString();
+    }
 
     PowerProfile profile = parsePowerProfile(ProfileName);
+    m_currentProfile = profile;
 
     emit currentPowerProfile(profile);
 }
@@ -204,4 +217,34 @@ PowerProfile PowerMonitor::parsePowerProfile(const QString &profile) {
     if (profile == "power-saver")
         return PowerProfile::PowerSaver;
     return PowerProfile::Unknown;
+}
+
+void PowerMonitor::setPowerProfile(const PowerProfile profile) {
+    if (isPowerProfileConnected && profile != m_currentProfile) {
+        QDBusInterface iface(
+            "net.hadess.PowerProfiles",
+            "/org/freedesktop/UPower/PowerProfiles",
+            "org.freedesktop.UPower.PowerProfiles",
+            QDBusConnection::systemBus()
+            );
+
+        QString profileStr;
+        switch (profile) {
+            case PowerProfile::Performance:
+                profileStr = "performance";
+                break;
+            case PowerProfile::Balanced:
+                profileStr = "balanced";
+                break;
+            case PowerProfile::PowerSaver:
+            case PowerProfile::Silent:
+                profileStr = "power-saver";
+                break;
+            default:
+                return;
+        }
+
+        iface.setProperty("ActiveProfile", profileStr);
+        m_currentProfile = profile;
+    }
 }

--- a/src/powermonitor.h
+++ b/src/powermonitor.h
@@ -40,6 +40,7 @@ public:
     void disconnectFromPowerProfiles();
     void queryChargerState();
     void queryPowerProfile();
+    void setPowerProfile(const PowerProfile profile);
 
     Q_ENUM(PowerProfile)
 
@@ -49,6 +50,7 @@ private:
 
     bool isUPowerConnected = false;
     bool isPowerProfileConnected = false;
+    PowerProfile m_currentProfile = PowerProfile::Unknown;
 
 signals:
     void currentChargerState(bool isOnline);

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+# Check if running as root
+if [ "$EUID" -ne 0 ]; then
+  echo "Please run this script with sudo:"
+  echo "  sudo $0"
+  exit 1
+fi
+
+echo "=== Uninstalling MControlCenter ==="
+rm -fv /usr/bin/mcontrolcenter
+rm -fv /usr/share/applications/mcontrolcenter.desktop
+rm -fv /usr/share/icons/hicolor/scalable/apps/mcontrolcenter.svg
+rm -fv /usr/libexec/mcontrolcenter-helper
+rm -fv /etc/dbus-1/system.d/mcontrolcenter-helper.conf
+rm -fv /usr/share/dbus-1/system.d/mcontrolcenter-helper.conf
+rm -fv /usr/share/dbus-1/system-services/mcontrolcenter.helper.service
+
+if [ -n "$SUDO_USER" ]; then
+    rm -fv "/home/$SUDO_USER/.local/share/applications/mcontrolcenter.desktop"
+fi
+
+# Kill helper if running
+killall mcontrolcenter-helper 2>/dev/null || true
+
+echo "=== Uninstallation successful! ==="


### PR DESCRIPTION
This PR improves power profile synchronization, resolves the startup/close overwrite issues, and simplifies the build and installation process with top-level scripts.

### Changes:
1. **Robust D-Bus Property Access**:
   - Refactored `queryPowerProfile()` and `queryChargerState()` in `PowerMonitor` to use Qt's native `iface.property()` instead of raw D-Bus `Get` calls.
   - Handled variant unpacking (adding `.canConvert<QDBusVariant>()` checks) to ensure compatibility on different D-Bus architectures.

2. **Wildcard Signal Connections**:
   - Updated D-Bus property signal connections to match any sender (passing `""` service name wildcard), resolving signal delivery failures caused by unique name or alias resolution mismatches.

3. **Low-power Mode Mappings Conflict Resolution**:
   - In `on_PowerProfileChange`, if the reported system profile is `PowerSaver`, it keeps either `Silent` or `Super Battery` mode if the hardware is already configured in one of those low-power modes, preventing the UI from overriding the user's manual preference.

4. **Startup Overwrite Prevention**:
   - Modified `loadSettings()` in `Operate` to check if `autoPPD` or `autoAcDc` are enabled on startup. If auto-profiles are active, it skips applying the saved `"UserMode"` to the EC, allowing the system's power state to be checked and synchronized bidirectionally on launch.

5. **Top-level One-click Installer and Uninstaller**:
   - Added `install.sh` and `uninstall.sh` at the repository root to clean, build, and deploy all binary components, system D-Bus configurations, and shortcuts in a single step.