### PR TITLE
Preserve advanced fan mode across user mode changes

### DIFF
--- a/src/operate.cpp
+++ b/src/operate.cpp
@@ -416,8 +416,16 @@ void Operate::setUserMode(user_mode userMode) const {
     if (msiEcHelper.hasShiftMode()) {
         msiEcHelper.setShiftMode(shiftMode);
     }
-    
-    if (msiEcHelper.hasFanMode()) {
+
+    // Custom fan curve (advanced mode) is orthogonal to the shift/user mode.
+    // Don't stomp it back to auto here - the UI resyncs the mode radio buttons
+    // (MainWindow::updateUserMode) right after settings are restored on startup,
+    // which re-enters this function and would otherwise silently drop advanced mode.
+    bool keepAdvanced = userMode != user_mode::silent_mode &&
+                        msiEcHelper.hasFanMode() &&
+                        getFanMode() == fan_mode::advanced_fan_mode;
+
+    if (msiEcHelper.hasFanMode() && !keepAdvanced) {
         msiEcHelper.setFanMode(fanMode);
     }
 


### PR DESCRIPTION
## Root cause

`Operate::setUserMode()` unconditionally forces `fan_mode` back to `auto`,
regardless of whether advanced/custom fan control is active.

On startup, `MainWindow::loadConfigs()` calls `operate.loadSettings()`
(which correctly restores `UserMode` first, then `fanModeAdvanced` last -
ending in advanced mode), immediately followed by `updateUserMode()`. That
function calls `radioButton->click()` to sync the UI, which fires the
button's `toggled` signal and re-enters `setUserMode()` as a side effect -
silently dropping advanced mode back to `auto` right after it was restored.

The same happens any time the shift/user mode changes while advanced is
active, not just at startup.

Confirmed at the raw EC register level (fan curve arrays stay correctly
loaded at their addresses, only `fan_mode` gets reset).

## Fix

Skip the `fan_mode` write in `setUserMode()` when advanced mode is already
active, unless the target mode is `silent_mode` (which intentionally
forces silent fan mode on purpose).

## Testing

Built from source, reproduced the bug pre-patch (fresh launch with
`fanModeAdvanced=true` saved always came up in `auto`). Post-patch, tested
two independent cold launches: `fan_mode` comes up and stays `advanced`
automatically, curve values unchanged, no manual re-toggle needed.

Fixes #246