### PR TITLE
Add verified msi-ec fan curve control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,11 @@ set(PROJECT_SOURCES
     src/powermonitor.cpp src/powermonitor.h
     src/helper.cpp src/helper.h
     src/msi-ec_helper.cpp src/msi-ec_helper.h
+    src/fan_curve.cpp src/fan_curve.h
+    src/helper/authorization.cpp src/helper/authorization.h
     src/settings.cpp src/settings.h
+    src/settings_parse.cpp
+    src/user_mode_policy.cpp src/user_mode_policy.h
     src/resources.qrc
 )
 
@@ -91,6 +95,36 @@ target_link_libraries(mcontrolcenter PRIVATE Qt${QT_VERSION_MAJOR}::Widgets Qt${
 install(TARGETS mcontrolcenter
     BUNDLE DESTINATION .
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+include(CTest)
+if(BUILD_TESTING)
+    find_package(Qt6 6.4 REQUIRED COMPONENTS Test)
+    add_executable(fan-curve-tests
+        tests/test_fan_curve.cpp
+        src/fan_curve.cpp
+        src/settings_parse.cpp
+        src/user_mode_policy.cpp
+        src/helper/fan-curve.cpp
+        src/helper/authorization.cpp
+    )
+    target_include_directories(fan-curve-tests PRIVATE src src/helper)
+    target_compile_definitions(fan-curve-tests PRIVATE FAN_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
+    target_link_libraries(fan-curve-tests PRIVATE Qt6::Core Qt6::DBus Qt6::Test)
+    add_test(NAME fan-curve-tests COMMAND fan-curve-tests)
+
+    find_program(DBUS_RUN_SESSION_EXECUTABLE dbus-run-session REQUIRED)
+    add_executable(dbus-context-tests
+        tests/test_dbus_context.cpp
+        src/fan_curve.cpp
+        src/helper/fan-curve.cpp
+        src/helper/msi-ec.cpp src/helper/msi-ec.h
+        src/helper/service.h
+    )
+    target_include_directories(dbus-context-tests PRIVATE src src/helper)
+    target_link_libraries(dbus-context-tests PRIVATE Qt6::Core Qt6::DBus Qt6::Test)
+    add_test(NAME dbus-context-tests
+        COMMAND ${DBUS_RUN_SESSION_EXECUTABLE} -- $<TARGET_FILE:dbus-context-tests>)
+endif()
 
 add_subdirectory(src/helper ${CMAKE_BINARY_DIR}/helper)
 add_definitions(-DMControlCenter_VERSION="${PROJECT_VERSION}")

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If your device is not on the list, follow the steps on the `msi-ec` github page 
 
 - If you're not installing from the packages, You'll need to install `libqt6widgets6` or its equivalent on your distribution (`qt6-base` for example). **the application will fail to open without it!** 
 
-- To get temperature and fan curve support, you'll need to install `ec_sys`, which comes installed on most distributions, or `acpi_sys` (fedora) with `write_support=1`. the app can still work with only `msi-ec` installed.
+- Fan control and performance modes use the typed `msi-ec` driver ABI. Keep raw EC write support disabled: the optional `ec_sys`/`acpi_ec` interface is used only for read-only legacy temperature and RPM diagnostics. The application can work with only `msi-ec` installed.
 
 ### Installation from packages
 <details open>

--- a/docs/fan_curve.md
+++ b/docs/fan_curve.md
@@ -1,0 +1,63 @@
+# Fan curve control contract
+
+MControlCenter uses the `BeardOverflow.msi_ec` D-Bus adaptor at `/msi_ec` for
+fan control. The application never writes fan points through the legacy EC byte
+interface. `msi_ec` is the authoritative control ABI; `ec_sys`/`acpi_ec` is an
+optional, read-only source for legacy RPM diagnostics.
+
+## Capability discovery
+
+`getFanCurveCapability()` returns a structured `a{sv}` map:
+
+- `supported`
+- `threshold_count`, `level_count`
+- `threshold_min`, `threshold_max`
+- `level_min`, `level_max`
+- `reason` when unsupported or incomplete
+
+Editing is supported only when all values describe the verified 6-threshold,
+7-level ABI (`0..100` thresholds and `0..150` raw EC fan levels) and all 26
+CPU/GPU sysfs point files plus `fan_mode` are present and readable.
+
+`getFanCurveProfile()` returns all 26 values whenever they are readable. The
+`readable` field is independent of `valid`: out-of-range or badly ordered
+values remain available so the editor can clamp them and repair the curve.
+Ordering, ranges, and exact counts are validated strictly only when applying.
+
+## Transaction
+
+`applyFanCurveTransaction(a{sv} profile)` is synchronous and returns:
+
+- `success`
+- `effective_mode`
+- `error`
+- `rollback_status` (`not-needed`, `succeeded`, `failed_auto`, or
+  `not-attempted`)
+
+The helper validates exact counts/ranges, strict threshold ordering, and
+nondecreasing levels. It snapshots the current mode and all 26 values, enters
+`auto`, writes every point, reads every point back, and only then activates
+`advanced`. Any failure first forces and verifies `auto`, restores and verifies
+the snapshot, and restores the original mode. If an Advanced snapshot has an
+invalid curve, its values are restored only under Auto and malformed Advanced
+is never reactivated. If safety cannot be proved it forces Auto and reports
+`failed_auto`.
+
+Successful readback is the only condition under which the application persists
+a firmware-bound verified profile. Legacy unscoped fan settings are not
+replayed. Silent and Super Battery selections clear a stale Advanced
+preference; only verified Balanced/Performance state may restore it after
+startup or resume.
+
+## Authorization and D-Bus
+
+Before each mutating D-Bus call, the unprivileged client runs a bounded
+(60-second) interactive `pkcheck` using its own unique system-bus name. The
+privileged helper independently checks the actual incoming unique sender with a
+short, noninteractive timeout and never displays an authentication dialog.
+Direct/non-D-Bus helper calls are denied. The helper-side check remains
+authoritative, and D-Bus calls use a timeout longer than that short check plus
+the bounded transaction.
+
+The arbitrary raw EC byte-write D-Bus method and Debug write control are not
+available.

--- a/scripts/create_installer.sh
+++ b/scripts/create_installer.sh
@@ -12,9 +12,10 @@ rm -f $DIST_DIR.tar.gz
 mkdir $DIST_DIR
 mkdir $APP_DIR
 
-cp ../build/mcontrolcenter $APP_DIR
-cp ../build/helper/mcontrolcenter-helper $APP_DIR
-cp ../src/helper/mcontrolcenter-helper.conf ../src/helper/mcontrolcenter.helper.service $APP_DIR
+cp ../build/mcontrolcenter "$APP_DIR"
+cp ../build/helper/mcontrolcenter-helper "$APP_DIR"
+cp ../src/helper/mcontrolcenter-helper.conf ../src/helper/mcontrolcenter.helper.service \
+   ../src/helper/org.mcontrolcenter.fan-control.policy "$APP_DIR"
 cp ../resources/mcontrolcenter.desktop ../resources/mcontrolcenter.svg $APP_DIR
 
 cp ./install.sh ./uninstall.sh $DIST_DIR

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,6 +6,7 @@ SCALABLE_ICONS_PATH='/usr/share/icons/hicolor/scalable/apps/'
 SHORTCUTS_PATH='/usr/share/applications/'
 DBUS_SYSTEM_PATH='/usr/share/dbus-1/system.d/'
 DBUS_SERVICES_PATH='/usr/share/dbus-1/system-services/'
+POLKIT_ACTIONS_PATH='/usr/share/polkit-1/actions/'
 
 APP_DIR='./app/'
 
@@ -15,21 +16,24 @@ SHORTCUT='mcontrolcenter.desktop'
 HELPER_BIN='mcontrolcenter-helper'
 DBUS_CONF='mcontrolcenter-helper.conf'
 DBUS_SERVICE='mcontrolcenter.helper.service'
+POLICY='org.mcontrolcenter.fan-control.policy'
 
 echo "Installation start"
 
-install -vDm755 $APP_DIR$APP_BIN $BIN_PATH$APP_BIN
+install -vDm755 "$APP_DIR$APP_BIN" "$BIN_PATH$APP_BIN"
 
 rm -fv /home/$SUDO_USER/.local/share/applications/$SHORTCUT
-install -vDm644 $APP_DIR$SHORTCUT $SHORTCUTS_PATH$SHORTCUT
+install -vDm644 "$APP_DIR$SHORTCUT" "$SHORTCUTS_PATH$SHORTCUT"
 
-install -vDm644 $APP_DIR$SVG_ICON $SCALABLE_ICONS_PATH$SVG_ICON
+install -vDm644 "$APP_DIR$SVG_ICON" "$SCALABLE_ICONS_PATH$SVG_ICON"
 
-install -vDm755 $APP_DIR$HELPER_BIN $LIB_EXEC_PATH$HELPER_BIN
+install -vDm755 "$APP_DIR$HELPER_BIN" "$LIB_EXEC_PATH$HELPER_BIN"
 
-install -vDm644 $APP_DIR$DBUS_CONF $DBUS_SYSTEM_PATH$DBUS_CONF
+install -vDm644 "$APP_DIR$DBUS_CONF" "$DBUS_SYSTEM_PATH$DBUS_CONF"
 
-install -vDm644 $APP_DIR$DBUS_SERVICE $DBUS_SERVICES_PATH$DBUS_SERVICE
+install -vDm644 "$APP_DIR$DBUS_SERVICE" "$DBUS_SERVICES_PATH$DBUS_SERVICE"
+
+install -vDm644 "$APP_DIR$POLICY" "$POLKIT_ACTIONS_PATH$POLICY"
 
 echo "Installation was successful"
 

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,16 +1,18 @@
 #!/bin/bash -e
 
 SHORTCUT='mcontrolcenter.desktop'
+POLICY='org.mcontrolcenter.fan-control.policy'
 
 echo "Start uninstall"
 
-rm -fv /usr/bin/mcontrolcenter
-rm -fv /usr/share/applications/$SHORTCUT
-rm -fv /home/$SUDO_USER/.local/share/applications/$SHORTCUT
-rm -fv /usr/share/icons/hicolor/scalable/apps/mcontrolcenter.svg
-rm -fv /usr/libexec/mcontrolcenter-helper
-rm -fv /etc/dbus-1/system.d/mcontrolcenter-helper.conf
-rm -fv /usr/share/dbus-1/system.d/mcontrolcenter-helper.conf
-rm -fv /usr/share/dbus-1/system-services/mcontrolcenter.helper.service
+rm -fv '/usr/bin/mcontrolcenter'
+rm -fv "/usr/share/applications/$SHORTCUT"
+rm -fv "/home/$SUDO_USER/.local/share/applications/$SHORTCUT"
+rm -fv '/usr/share/icons/hicolor/scalable/apps/mcontrolcenter.svg'
+rm -fv '/usr/libexec/mcontrolcenter-helper'
+rm -fv '/etc/dbus-1/system.d/mcontrolcenter-helper.conf'
+rm -fv '/usr/share/dbus-1/system.d/mcontrolcenter-helper.conf'
+rm -fv '/usr/share/dbus-1/system-services/mcontrolcenter.helper.service'
+rm -fv "/usr/share/polkit-1/actions/$POLICY"
 
 echo "Uninstall was successful"

--- a/src/fan_curve.cpp
+++ b/src/fan_curve.cpp
@@ -1,0 +1,185 @@
+#include "fan_curve.h"
+
+#include <QDBusArgument>
+#include <QDBusVariant>
+#include <QVariantList>
+
+namespace {
+QVector<int> vectorFromVariant(const QVariant &value, bool *ok) {
+    QVector<int> result;
+    *ok = false;
+    if (!value.isValid())
+        return {};
+
+    QVariantList list;
+    if (value.metaType() == QMetaType::fromType<QDBusArgument>()) {
+        const QDBusArgument argument = qvariant_cast<QDBusArgument>(value);
+        if (argument.currentSignature() != QStringLiteral("av"))
+            return {};
+        argument.beginArray();
+        while (!argument.atEnd()) {
+            QDBusVariant wrapped;
+            argument >> wrapped;
+            list.append(wrapped.variant());
+        }
+        argument.endArray();
+    } else if (value.canConvert<QVariantList>()) {
+        list = value.toList();
+    } else {
+        return {};
+    }
+
+    result.reserve(list.size());
+    for (const QVariant &entry : list) {
+        bool converted = false;
+        const int number = entry.toInt(&converted);
+        if (!converted)
+            return {};
+        result.append(number);
+    }
+    *ok = true;
+    return result;
+}
+
+QVariantList variantFromVector(const QVector<int> &values) {
+    QVariantList result;
+    result.reserve(values.size());
+    for (const int value : values)
+        result.append(value);
+    return result;
+}
+}
+
+bool FanCurveCapability::complete() const noexcept {
+    return supported && thresholdCount == 6 && levelCount == 7 &&
+           thresholdMin == 0 && thresholdMax == 100 &&
+           levelMin == 0 && levelMax == 150;
+}
+
+bool FanCurveProfile::complete() const noexcept {
+    return cpuThresholds.size() == 6 && cpuLevels.size() == 7 &&
+           gpuThresholds.size() == 6 && gpuLevels.size() == 7;
+}
+
+QString fanCurveProfileWithinRanges(const FanCurveCapability &capability,
+                                    const FanCurveProfile &profile) {
+    if (!capability.complete())
+        return QStringLiteral("unsupported or incomplete fan curve ABI");
+    if (!profile.complete())
+        return QStringLiteral("fan curve must contain exactly 6 thresholds and 7 levels per fan");
+    for (const QVector<int> *thresholds : {&profile.cpuThresholds, &profile.gpuThresholds}) {
+        for (const int value : *thresholds) {
+            if (value < capability.thresholdMin || value > capability.thresholdMax)
+                return QStringLiteral("threshold outside driver range");
+        }
+    }
+    for (const QVector<int> *levels : {&profile.cpuLevels, &profile.gpuLevels}) {
+        for (const int value : *levels) {
+            if (value < capability.levelMin || value > capability.levelMax)
+                return QStringLiteral("fan level outside driver range");
+        }
+    }
+    return {};
+}
+
+QString validateFanCurve(const FanCurveCapability &capability,
+                         const FanCurveProfile &profile) {
+    if (const QString error = fanCurveProfileWithinRanges(capability, profile); !error.isEmpty())
+        return error;
+    const auto validateThresholds = [](const QVector<int> &values) -> QString {
+        for (int i = 1; i < values.size(); ++i) {
+            if (values[i] <= values[i - 1])
+                return QStringLiteral("thresholds must be strictly ascending");
+        }
+        return {};
+    };
+    const auto validateLevels = [](const QVector<int> &values) -> QString {
+        for (int i = 1; i < values.size(); ++i) {
+            if (values[i] < values[i - 1])
+                return QStringLiteral("fan levels must be nondecreasing");
+        }
+        return {};
+    };
+    for (const QVector<int> *thresholds : {&profile.cpuThresholds, &profile.gpuThresholds}) {
+        if (const QString error = validateThresholds(*thresholds); !error.isEmpty())
+            return error;
+    }
+    for (const QVector<int> *levels : {&profile.cpuLevels, &profile.gpuLevels}) {
+        if (const QString error = validateLevels(*levels); !error.isEmpty())
+            return error;
+    }
+    return {};
+}
+
+bool fanCurveFirmwareMatches(const QString &savedVersion,
+                              const QString &savedDate,
+                              const QString &currentVersion,
+                              const QString &currentDate) {
+    return !savedVersion.isEmpty() && !savedDate.isEmpty() &&
+           savedVersion == currentVersion && savedDate == currentDate;
+}
+
+QVariantMap fanCurveCapabilityToMap(const FanCurveCapability &capability) {
+    return {{QStringLiteral("supported"), capability.supported},
+            {QStringLiteral("threshold_count"), capability.thresholdCount},
+            {QStringLiteral("level_count"), capability.levelCount},
+            {QStringLiteral("threshold_min"), capability.thresholdMin},
+            {QStringLiteral("threshold_max"), capability.thresholdMax},
+            {QStringLiteral("level_min"), capability.levelMin},
+            {QStringLiteral("level_max"), capability.levelMax},
+            {QStringLiteral("reason"), capability.reason}};
+}
+
+FanCurveCapability fanCurveCapabilityFromMap(const QVariantMap &map) {
+    FanCurveCapability capability;
+    capability.supported = map.value(QStringLiteral("supported")).toBool();
+    capability.thresholdCount = map.value(QStringLiteral("threshold_count")).toInt();
+    capability.levelCount = map.value(QStringLiteral("level_count")).toInt();
+    capability.thresholdMin = map.value(QStringLiteral("threshold_min")).toInt();
+    capability.thresholdMax = map.value(QStringLiteral("threshold_max")).toInt();
+    capability.levelMin = map.value(QStringLiteral("level_min")).toInt();
+    capability.levelMax = map.value(QStringLiteral("level_max")).toInt();
+    capability.reason = map.value(QStringLiteral("reason")).toString();
+    return capability;
+}
+
+QVariantMap fanCurveProfileToMap(const FanCurveProfile &profile) {
+    return {{QStringLiteral("cpu_thresholds"), variantFromVector(profile.cpuThresholds)},
+            {QStringLiteral("cpu_levels"), variantFromVector(profile.cpuLevels)},
+            {QStringLiteral("gpu_thresholds"), variantFromVector(profile.gpuThresholds)},
+            {QStringLiteral("gpu_levels"), variantFromVector(profile.gpuLevels)}};
+}
+
+bool fanCurveProfileFromMap(const QVariantMap &map, FanCurveProfile *profile) {
+    if (!profile)
+        return false;
+    bool okCpuThresholds = false;
+    bool okCpuLevels = false;
+    bool okGpuThresholds = false;
+    bool okGpuLevels = false;
+    FanCurveProfile candidate;
+    candidate.cpuThresholds = vectorFromVariant(map.value(QStringLiteral("cpu_thresholds")), &okCpuThresholds);
+    candidate.cpuLevels = vectorFromVariant(map.value(QStringLiteral("cpu_levels")), &okCpuLevels);
+    candidate.gpuThresholds = vectorFromVariant(map.value(QStringLiteral("gpu_thresholds")), &okGpuThresholds);
+    candidate.gpuLevels = vectorFromVariant(map.value(QStringLiteral("gpu_levels")), &okGpuLevels);
+    if (!okCpuThresholds || !okCpuLevels || !okGpuThresholds || !okGpuLevels)
+        return false;
+    *profile = candidate;
+    return true;
+}
+
+QVariantMap fanCurveResultToMap(const FanCurveResult &result) {
+    return {{QStringLiteral("success"), result.success},
+            {QStringLiteral("effective_mode"), result.effectiveMode},
+            {QStringLiteral("error"), result.error},
+            {QStringLiteral("rollback_status"), result.rollbackStatus}};
+}
+
+FanCurveResult fanCurveResultFromMap(const QVariantMap &map) {
+    FanCurveResult result;
+    result.success = map.value(QStringLiteral("success")).toBool();
+    result.effectiveMode = map.value(QStringLiteral("effective_mode")).toString();
+    result.error = map.value(QStringLiteral("error")).toString();
+    result.rollbackStatus = map.value(QStringLiteral("rollback_status")).toString();
+    return result;
+}

--- a/src/fan_curve.h
+++ b/src/fan_curve.h
@@ -1,0 +1,71 @@
+/* Copyright (C) 2026 MControlCenter contributors
+ *
+ * Typed fan-curve capability, profile, and transaction result boundary.
+ */
+#ifndef FAN_CURVE_H
+#define FAN_CURVE_H
+
+#include <QVariantMap>
+#include <QVector>
+#include <QString>
+
+struct FanCurveCapability {
+    bool supported = false;
+    int thresholdCount = 0;
+    int levelCount = 0;
+    int thresholdMin = 0;
+    int thresholdMax = 0;
+    int levelMin = 0;
+    int levelMax = 0;
+    QString reason;
+
+    [[nodiscard]] bool complete() const noexcept;
+};
+
+struct FanCurveProfile {
+    QVector<int> cpuThresholds;
+    QVector<int> cpuLevels;
+    QVector<int> gpuThresholds;
+    QVector<int> gpuLevels;
+
+    [[nodiscard]] bool complete() const noexcept;
+    friend bool operator==(const FanCurveProfile &left, const FanCurveProfile &right) noexcept {
+        return left.cpuThresholds == right.cpuThresholds && left.cpuLevels == right.cpuLevels &&
+               left.gpuThresholds == right.gpuThresholds && left.gpuLevels == right.gpuLevels;
+    }
+};
+
+struct FanCurveState {
+    QString mode;
+    FanCurveProfile profile;
+    bool readable = false;
+};
+
+struct FanCurveResult {
+    bool success = false;
+    QString effectiveMode;
+    QString error;
+    QString rollbackStatus;
+
+    [[nodiscard]] bool rolledBack() const noexcept { return rollbackStatus == QStringLiteral("succeeded"); }
+};
+
+// Validation is deliberately independent of Qt widgets and sysfs so that it can
+// be exercised with a fake backend without touching hardware.
+[[nodiscard]] QString fanCurveProfileWithinRanges(const FanCurveCapability &capability,
+                                                  const FanCurveProfile &profile);
+[[nodiscard]] QString validateFanCurve(const FanCurveCapability &capability,
+                                       const FanCurveProfile &profile);
+[[nodiscard]] bool fanCurveFirmwareMatches(const QString &savedVersion,
+                                           const QString &savedDate,
+                                           const QString &currentVersion,
+                                           const QString &currentDate);
+
+[[nodiscard]] QVariantMap fanCurveCapabilityToMap(const FanCurveCapability &capability);
+[[nodiscard]] FanCurveCapability fanCurveCapabilityFromMap(const QVariantMap &map);
+[[nodiscard]] QVariantMap fanCurveProfileToMap(const FanCurveProfile &profile);
+[[nodiscard]] bool fanCurveProfileFromMap(const QVariantMap &map, FanCurveProfile *profile);
+[[nodiscard]] QVariantMap fanCurveResultToMap(const FanCurveResult &result);
+[[nodiscard]] FanCurveResult fanCurveResultFromMap(const QVariantMap &map);
+
+#endif // FAN_CURVE_H

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "helper/service.h"
+#include "helper/authorization.h"
 #include "helper.h"
 #include "mainwindow.h"
 
@@ -34,10 +35,15 @@ Helper::Helper() {
         fprintf(stderr, "Cannot connect to the D-Bus system bus");
         return;
     }
-    iface = new QDBusInterface(SERVICE_NAME, "/", INTERFACE_NAME, QDBusConnection::systemBus());
+    iface = new QDBusInterface(SERVICE_NAME, "/", INTERFACE_NAME,
+                               QDBusConnection::systemBus(), this);
+    iface->setTimeout(FAN_DBUS_TIMEOUT_MS);
+    iface->setInteractiveAuthorizationAllowed(false);
 }
 
 bool Helper::isEcSysModuleLoaded() {
+    if (!iface)
+        return false;
     if (QDBusReply<bool> reply = iface->call("isEcSysModuleLoaded"); reply.isValid())
         return reply.value();
     printError(iface->lastError());
@@ -45,6 +51,8 @@ bool Helper::isEcSysModuleLoaded() {
 }
 
 bool Helper::loadEcSysModule() {
+    if (!iface || !preauthorizeHardwareMutation())
+        return false;
     if (QDBusReply<bool> reply = iface->call("loadEcSysModule"); reply.isValid())
         return reply.value();
     printError(iface->lastError());
@@ -52,6 +60,8 @@ bool Helper::loadEcSysModule() {
 }
 
 bool Helper::updateData() {
+    if (!iface)
+        return false;
     if (QDBusReply<QByteArray> reply = iface->call("getData"); reply.isValid() &&
                                                                reply.value().size() == EC_SPACE_SIZE) {
         ecData = reply.value();
@@ -62,6 +72,8 @@ bool Helper::updateData() {
 }
 
 void Helper::updateDataAsync() {
+    if (!iface)
+        return;
     QDBusPendingCall async = iface->asyncCall("getData");
     QDBusPendingCallWatcher const *watcher = new QDBusPendingCallWatcher(async, this);
 
@@ -92,18 +104,6 @@ int Helper::getValue(int address) const {
 
 QByteArray Helper::getValues(int startAddress, int size) const {
     return ecData.mid(startAddress, size);
-}
-
-void Helper::putValue(int address, int value) {
-    if (getValue(address) == value)
-        return;
-    iface->call("putValue", address, value);
-    printError(iface->lastError());
-}
-
-void Helper::quit() {
-    iface->call("quit");
-    printError(iface->lastError());
 }
 
 void Helper::printError(QDBusError const & error) const {

--- a/src/helper.h
+++ b/src/helper.h
@@ -36,9 +36,7 @@ public:
     std::optional<int> getOptionalValue(int address) const;
     int getValue(int address) const;
     QByteArray getValues(int startAddress, int size) const;
-    void putValue(int address, int value);
-    void quit();
-    QDBusInterface *iface;
+    QDBusInterface *iface = nullptr;
 private:
     void printError(QDBusError const & error) const;
 private slots:

--- a/src/helper/CMakeLists.txt
+++ b/src/helper/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.25)
 
 project(MControlCenterHelper LANGUAGES CXX)
 
+include(GNUInstallDirs)
+
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 set(CMAKE_AUTOUIC ON)
@@ -16,14 +18,23 @@ add_compile_options(-fPIC)
 find_package(Qt6 6.4 REQUIRED COMPONENTS Core DBus)
 
 add_executable(mcontrolcenter-helper
+  service.h
   helper.h
   helper.cpp
   readwrite.h
   readwrite.cpp
   msi-ec.h
   msi-ec.cpp
+  fan-curve.h
+  fan-curve.cpp
+  ../fan_curve.h
+  ../fan_curve.cpp
+  authorization.h
+  authorization.cpp
 )
 target_link_libraries(mcontrolcenter-helper Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::DBus)
 
 install(TARGETS mcontrolcenter-helper
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    RUNTIME DESTINATION ${CMAKE_INSTALL_LIBEXECDIR})
+install(FILES org.mcontrolcenter.fan-control.policy
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/polkit-1/actions)

--- a/src/helper/authorization.cpp
+++ b/src/helper/authorization.cpp
@@ -1,0 +1,54 @@
+#include "authorization.h"
+
+#include <QDBusConnection>
+#include <QDBusMessage>
+#include <QProcess>
+
+namespace {
+bool runPolicyKitCheck(const QStringList &arguments, int timeoutMs) {
+    QProcess check;
+    check.start(QStringLiteral("/usr/bin/pkcheck"), arguments);
+    if (!check.waitForFinished(timeoutMs)) {
+        check.kill();
+        check.waitForFinished(100);
+        return false;
+    }
+    return check.exitStatus() == QProcess::NormalExit && check.exitCode() == 0;
+}
+}
+
+QStringList policyKitArgumentsForBusName(const QString &sender, bool allowInteraction) {
+    QStringList args{QStringLiteral("--action-id"),
+                     QStringLiteral("org.mcontrolcenter.fan-control"),
+                     QStringLiteral("--system-bus-name"), sender};
+    if (allowInteraction)
+        args.append(QStringLiteral("--allow-user-interaction"));
+    return args;
+}
+
+bool preauthorizeHardwareMutation() {
+    const QDBusConnection bus = QDBusConnection::systemBus();
+    const QString sender = bus.baseService();
+    if (!bus.isConnected() || sender.isEmpty())
+        return false;
+    return runPolicyKitCheck(policyKitArgumentsForBusName(sender, true),
+                             FAN_AUTHORIZATION_TIMEOUT_MS);
+}
+
+bool authorizeHardwareMutation(const QDBusContext &context) {
+    // Direct C++ calls have no authenticated caller. They must not silently
+    // become a root write; transaction tests use a fake backend directly.
+    if (!context.calledFromDBus())
+        return false;
+
+    // Qt exposes the authenticated incoming unique bus name as service() on
+    // the QDBusContext message (QDBusMessage has no sender() accessor).
+    const QString sender = context.message().service();
+    if (!context.connection().isConnected() || sender.isEmpty())
+        return false;
+
+    // The helper check is deliberately noninteractive and short. The client
+    // must have completed any user interaction before invoking this method.
+    return runPolicyKitCheck(policyKitArgumentsForBusName(sender, false),
+                             FAN_HELPER_AUTHORIZATION_TIMEOUT_MS);
+}

--- a/src/helper/authorization.h
+++ b/src/helper/authorization.h
@@ -1,0 +1,24 @@
+#ifndef MCONTROL_CENTER_AUTHORIZATION_H
+#define MCONTROL_CENTER_AUTHORIZATION_H
+
+#include <QtDBus/QDBusContext>
+#include <QStringList>
+
+// Interactive authorization is performed by the unprivileged client. The
+// helper only performs a short, noninteractive independent check.
+constexpr int FAN_AUTHORIZATION_TIMEOUT_MS = 60000;
+constexpr int FAN_HELPER_AUTHORIZATION_TIMEOUT_MS = 3000;
+constexpr int FAN_DBUS_TIMEOUT_MS = 10000;
+
+[[nodiscard]] QStringList policyKitArgumentsForBusName(const QString &sender,
+                                                        bool allowInteraction);
+
+// Client-side preauthorization. The process is intentionally local to the UI;
+// no helper event-loop call can display an authentication dialog.
+[[nodiscard]] bool preauthorizeHardwareMutation();
+
+// All mutating helper calls are root hardware operations. The caller's unique
+// system-bus name is checked by PolicyKit; direct C++ calls are denied.
+[[nodiscard]] bool authorizeHardwareMutation(const QDBusContext &context);
+
+#endif // MCONTROL_CENTER_AUTHORIZATION_H

--- a/src/helper/fan-curve.cpp
+++ b/src/helper/fan-curve.cpp
@@ -1,0 +1,279 @@
+#include "fan-curve.h"
+
+#include <QFile>
+
+namespace {
+const QString fanCurveSupported = QStringLiteral("fan_curve_supported");
+const QString thresholdCount = QStringLiteral("fan_curve_threshold_count");
+const QString levelCount = QStringLiteral("fan_curve_level_count");
+const QString thresholdMin = QStringLiteral("fan_curve_threshold_min");
+const QString thresholdMax = QStringLiteral("fan_curve_threshold_max");
+const QString levelMin = QStringLiteral("fan_curve_level_min");
+const QString levelMax = QStringLiteral("fan_curve_level_max");
+
+bool parseInt(const QString &text, int *value) {
+    bool ok = false;
+    const int parsed = text.trimmed().toInt(&ok);
+    if (ok && value)
+        *value = parsed;
+    return ok;
+}
+}
+
+SysfsFanCurveBackend::SysfsFanCurveBackend(QString root) : root(std::move(root)) {}
+
+bool writeFanModeVerified(FanCurveBackend &backend, const QString &mode, QString *error) {
+    if (mode != QStringLiteral("auto") && mode != QStringLiteral("silent") &&
+        mode != QStringLiteral("basic") && mode != QStringLiteral("advanced")) {
+        if (error)
+            *error = QStringLiteral("invalid fan mode");
+        return false;
+    }
+    if (!backend.writeMode(mode, error))
+        return false;
+    if (backend.readMode() != mode) {
+        if (error)
+            *error = QStringLiteral("fan mode readback did not match requested mode");
+        return false;
+    }
+    return true;
+}
+
+QString SysfsFanCurveBackend::pathFor(const QString &fan, const QString &kind, int index) const {
+    return root + QLatin1Char('/') + fan + QStringLiteral("/fan_curve_") + kind +
+           QLatin1Char('_') + QString::number(index);
+}
+
+QString SysfsFanCurveBackend::read(const QString &path, QString *error) const {
+    QFile file(path);
+    if (!file.exists() || !file.open(QIODevice::ReadOnly)) {
+        if (error)
+            *error = QStringLiteral("cannot read %1").arg(path);
+        return {};
+    }
+    return QString::fromUtf8(file.readAll()).trimmed();
+}
+
+bool SysfsFanCurveBackend::write(const QString &path, const QString &value, QString *error) {
+    QFile file(path);
+    if (!file.exists() || !file.open(QIODevice::WriteOnly) ||
+        file.write(value.toUtf8()) != value.toUtf8().size()) {
+        if (error)
+            *error = QStringLiteral("cannot write %1").arg(path);
+        return false;
+    }
+    return true;
+}
+
+FanCurveCapability SysfsFanCurveBackend::capability() const {
+    FanCurveCapability capability;
+    QString text;
+    text = read(root + QLatin1Char('/') + fanCurveSupported);
+    int supported = 0;
+    if (!parseInt(text, &supported) || supported != 1) {
+        capability.reason = QStringLiteral("driver does not advertise fan curve support");
+        return capability;
+    }
+    const auto readCapability = [&](const QString &name, int *field) -> bool {
+        QString error;
+        const QString value = read(root + QLatin1Char('/') + name, &error);
+        return parseInt(value, field);
+    };
+    if (!readCapability(thresholdCount, &capability.thresholdCount) ||
+        !readCapability(levelCount, &capability.levelCount) ||
+        !readCapability(thresholdMin, &capability.thresholdMin) ||
+        !readCapability(thresholdMax, &capability.thresholdMax) ||
+        !readCapability(levelMin, &capability.levelMin) ||
+        !readCapability(levelMax, &capability.levelMax)) {
+        capability.reason = QStringLiteral("driver fan curve capability is incomplete");
+        return capability;
+    }
+    capability.supported = true;
+    if (!capability.complete()) {
+        capability.reason = QStringLiteral("driver fan curve capability has unexpected counts or ranges");
+        return capability;
+    }
+    // Metadata alone is not a usable ABI. Confirm every point and the mode
+    // control exist before exposing the capability to the application.
+    if (!QFile::exists(root + QStringLiteral("/fan_mode"))) {
+        capability.supported = false;
+        capability.reason = QStringLiteral("fan mode control is missing");
+        return capability;
+    }
+    for (const QString &fan : {QStringLiteral("cpu"), QStringLiteral("gpu")}) {
+        for (const QString &kind : {QStringLiteral("threshold"), QStringLiteral("level")}) {
+            const int count = kind == QStringLiteral("threshold") ? capability.thresholdCount : capability.levelCount;
+            for (int index = 1; index <= count; ++index) {
+                if (!QFile::exists(pathFor(fan, kind, index))) {
+                    capability.supported = false;
+                    capability.reason = QStringLiteral("fan curve ABI is missing %1/%2_%3")
+                                             .arg(fan, kind).arg(index);
+                    return capability;
+                }
+            }
+        }
+    }
+    FanCurveProfile probe;
+    QString probeError;
+    if (readMode().isEmpty() || !readProfile(&probe, &probeError)) {
+        capability.supported = false;
+        capability.reason = probeError.isEmpty() ? QStringLiteral("fan curve ABI cannot be read") : probeError;
+    }
+    return capability;
+}
+
+bool SysfsFanCurveBackend::readProfile(FanCurveProfile *profile, QString *error) const {
+    if (!profile)
+        return false;
+    FanCurveProfile result;
+    const auto readValues = [&](const QString &fan, const QString &kind, int count,
+                                QVector<int> *values) -> bool {
+        for (int index = 1; index <= count; ++index) {
+            QString readError;
+            const QString text = read(pathFor(fan, kind, index), &readError);
+            int value = 0;
+            if (!parseInt(text, &value)) {
+                if (error)
+                    *error = readError.isEmpty() ? QStringLiteral("invalid fan curve value") : readError;
+                return false;
+            }
+            values->append(value);
+        }
+        return true;
+    };
+    if (!readValues(QStringLiteral("cpu"), QStringLiteral("threshold"), 6, &result.cpuThresholds) ||
+        !readValues(QStringLiteral("cpu"), QStringLiteral("level"), 7, &result.cpuLevels) ||
+        !readValues(QStringLiteral("gpu"), QStringLiteral("threshold"), 6, &result.gpuThresholds) ||
+        !readValues(QStringLiteral("gpu"), QStringLiteral("level"), 7, &result.gpuLevels))
+        return false;
+    *profile = result;
+    return true;
+}
+
+QString SysfsFanCurveBackend::readMode() const {
+    return read(root + QStringLiteral("/fan_mode"));
+}
+
+bool SysfsFanCurveBackend::writeMode(const QString &mode, QString *error) {
+    if (mode != QStringLiteral("auto") && mode != QStringLiteral("silent") &&
+        mode != QStringLiteral("basic") && mode != QStringLiteral("advanced")) {
+        if (error)
+            *error = QStringLiteral("invalid fan mode");
+        return false;
+    }
+    return write(root + QStringLiteral("/fan_mode"), mode, error);
+}
+
+bool SysfsFanCurveBackend::writePoint(const QString &fan, const QString &kind, int index,
+                                      int value, QString *error) {
+    return write(pathFor(fan, kind, index), QString::number(value), error);
+}
+
+bool FanCurveTransaction::writeProfile(const FanCurveProfile &profile, QString *error) {
+    const auto writeValues = [&](const QString &fan, const QString &kind,
+                                 const QVector<int> &values) -> bool {
+        for (int i = 0; i < values.size(); ++i) {
+            if (!backend.writePoint(fan, kind, i + 1, values[i], error))
+                return false;
+        }
+        return true;
+    };
+    return writeValues(QStringLiteral("cpu"), QStringLiteral("threshold"), profile.cpuThresholds) &&
+           writeValues(QStringLiteral("cpu"), QStringLiteral("level"), profile.cpuLevels) &&
+           writeValues(QStringLiteral("gpu"), QStringLiteral("threshold"), profile.gpuThresholds) &&
+           writeValues(QStringLiteral("gpu"), QStringLiteral("level"), profile.gpuLevels);
+}
+
+bool FanCurveTransaction::profileMatches(const FanCurveProfile &profile, QString *error) const {
+    FanCurveProfile readback;
+    if (!backend.readProfile(&readback, error))
+        return false;
+    if (readback.cpuThresholds != profile.cpuThresholds ||
+        readback.cpuLevels != profile.cpuLevels ||
+        readback.gpuThresholds != profile.gpuThresholds ||
+        readback.gpuLevels != profile.gpuLevels) {
+        if (error)
+            *error = QStringLiteral("fan curve readback did not match requested values");
+        return false;
+    }
+    return true;
+}
+
+bool FanCurveTransaction::restore(const FanCurveProfile &profile, const QString &mode, QString *error) {
+    // Never rewrite points while Advanced (or another mode) may consume them.
+    // Force a known safe mode before restoring the snapshot values.
+    if (!writeFanModeVerified(backend, QStringLiteral("auto"), error))
+        return false;
+    if (!writeProfile(profile, error) || !profileMatches(profile, error))
+        return false;
+    if (!writeFanModeVerified(backend, mode, error)) {
+        if (error && error->isEmpty())
+            *error = QStringLiteral("fan mode rollback readback failed");
+        return false;
+    }
+    return true;
+}
+
+FanCurveResult FanCurveTransaction::apply(const FanCurveProfile &profile) {
+    FanCurveResult result;
+    result.rollbackStatus = QStringLiteral("not-needed");
+    const FanCurveCapability capability = backend.capability();
+    if (const QString validationError = validateFanCurve(capability, profile); !validationError.isEmpty()) {
+        result.error = validationError;
+        result.effectiveMode = backend.readMode();
+        return result;
+    }
+
+    FanCurveProfile snapshot;
+    QString error;
+    const QString snapshotMode = backend.readMode();
+    if (snapshotMode.isEmpty() || !backend.readProfile(&snapshot, &error)) {
+        result.error = error.isEmpty() ? QStringLiteral("could not snapshot current fan curve") : error;
+        result.effectiveMode = snapshotMode;
+        return result;
+    }
+
+    // A readable but malformed snapshot must never be reactivated as
+    // Advanced. It can still be restored as data, but only while Auto is active.
+    const bool snapshotCurveValid = validateFanCurve(capability, snapshot).isEmpty();
+    const QString rollbackMode = (snapshotMode == QStringLiteral("advanced") && !snapshotCurveValid)
+                                     ? QStringLiteral("auto") : snapshotMode;
+
+    auto failAndRollback = [&](const QString &failure) {
+        result.success = false;
+        result.error = failure;
+        QString rollbackError;
+        if (restore(snapshot, rollbackMode, &rollbackError)) {
+            result.rollbackStatus = QStringLiteral("succeeded");
+            result.effectiveMode = rollbackMode;
+        } else {
+            // A partially written EC curve is unsafe.  Auto is the only safe
+            // mode that does not consume the potentially inconsistent curve.
+            QString autoError;
+            const bool autoVerified = writeFanModeVerified(backend, QStringLiteral("auto"), &autoError);
+            result.rollbackStatus = QStringLiteral("failed_auto");
+            result.effectiveMode = autoVerified ? QStringLiteral("auto") : backend.readMode();
+            if (!autoVerified && !autoError.isEmpty())
+                result.error += QStringLiteral("; auto fallback failed: ") + autoError;
+        }
+    };
+
+    if (snapshotMode != QStringLiteral("auto")) {
+        if (!writeFanModeVerified(backend, QStringLiteral("auto"), &error)) {
+            failAndRollback(error.isEmpty() ? QStringLiteral("could not enter auto mode") : error);
+            return result;
+        }
+    }
+    if (!writeProfile(profile, &error) || !profileMatches(profile, &error)) {
+        failAndRollback(error.isEmpty() ? QStringLiteral("fan curve write failed") : error);
+        return result;
+    }
+    if (!writeFanModeVerified(backend, QStringLiteral("advanced"), &error)) {
+        failAndRollback(error.isEmpty() ? QStringLiteral("could not activate advanced mode") : error);
+        return result;
+    }
+    result.success = true;
+    result.effectiveMode = QStringLiteral("advanced");
+    result.error.clear();
+    return result;
+}

--- a/src/helper/fan-curve.h
+++ b/src/helper/fan-curve.h
@@ -1,0 +1,55 @@
+#ifndef HELPER_FAN_CURVE_H
+#define HELPER_FAN_CURVE_H
+
+#include "../fan_curve.h"
+
+#include <QString>
+
+class FanCurveBackend {
+public:
+    virtual ~FanCurveBackend() = default;
+    [[nodiscard]] virtual FanCurveCapability capability() const = 0;
+    [[nodiscard]] virtual bool readProfile(FanCurveProfile *profile, QString *error) const = 0;
+    [[nodiscard]] virtual QString readMode() const = 0;
+    virtual bool writeMode(const QString &mode, QString *error) = 0;
+    virtual bool writePoint(const QString &fan, const QString &kind, int index,
+                            int value, QString *error) = 0;
+};
+
+// Write a mode and require an exact readback. Invalid modes are rejected
+// before any sysfs/EC write.
+[[nodiscard]] bool writeFanModeVerified(FanCurveBackend &backend, const QString &mode,
+                                         QString *error = nullptr);
+
+class SysfsFanCurveBackend final : public FanCurveBackend {
+public:
+    explicit SysfsFanCurveBackend(QString root = QStringLiteral("/sys/devices/platform/msi-ec"));
+
+    [[nodiscard]] FanCurveCapability capability() const override;
+    [[nodiscard]] bool readProfile(FanCurveProfile *profile, QString *error) const override;
+    [[nodiscard]] QString readMode() const override;
+    bool writeMode(const QString &mode, QString *error) override;
+    bool writePoint(const QString &fan, const QString &kind, int index,
+                    int value, QString *error) override;
+
+private:
+    QString root;
+    [[nodiscard]] QString pathFor(const QString &fan, const QString &kind, int index) const;
+    [[nodiscard]] QString read(const QString &path, QString *error = nullptr) const;
+    bool write(const QString &path, const QString &value, QString *error);
+};
+
+class FanCurveTransaction {
+public:
+    explicit FanCurveTransaction(FanCurveBackend &backend) : backend(backend) {}
+
+    [[nodiscard]] FanCurveResult apply(const FanCurveProfile &profile);
+
+private:
+    FanCurveBackend &backend;
+    bool writeProfile(const FanCurveProfile &profile, QString *error);
+    bool profileMatches(const FanCurveProfile &profile, QString *error) const;
+    bool restore(const FanCurveProfile &profile, const QString &mode, QString *error);
+};
+
+#endif // HELPER_FAN_CURVE_H

--- a/src/helper/helper.cpp
+++ b/src/helper/helper.cpp
@@ -19,27 +19,16 @@
 #include "helper.h"
 #include "msi-ec.h"
 #include "readwrite.h"
+#include "authorization.h"
 #include <QCoreApplication>
 #include <QDBusConnection>
 #include <QDBusError>
 #include <QProcess>
-#include <QTimer>
 
 ReadWrite rw;
 
-void Helper::quit() const {
-    QTimer::singleShot(0, QCoreApplication::instance(), &QCoreApplication::quit);
-}
-
 QByteArray Helper::getData() const {
     return rw.readFromFile();
-}
-
-void Helper::putValue(const int &address, const int &value) const {
-    if (value >= 0 && value <= 255)
-        rw.writeToFile(address, value);
-    else
-        fprintf(stderr, "tried to input invalid value. Address: %d, value: %d\n", address, value);
 }
 
 bool Helper::isEcSysModuleLoaded() const {
@@ -55,9 +44,16 @@ bool Helper::isEcSysModuleLoaded() const {
 }
 
 bool Helper::loadEcSysModule() const {
+    if (!authorizeHardwareMutation(context.callContext())) {
+        context.sendCallError(QDBusError::AccessDenied,
+                              QStringLiteral("PolicyKit authorization required"));
+        return false;
+    }
     fprintf(stderr, "%s\n", qPrintable("Trying to load the ec_sys kernel module"));
     auto *process = new QProcess();
-    process->start("sh", QStringList() << "-c" << "/usr/sbin/modprobe ec_sys write_support=1 2>&1");
+    // Raw EC writes are intentionally unavailable. Load ec_sys read-only so
+    // diagnostics can continue without enabling any debugfs write support.
+    process->start("/usr/sbin/modprobe", QStringList() << "ec_sys");
     process->waitForFinished(1000);
     if (QByteArray output = process->readAllStandardOutput(); output != "")
         fprintf(stderr, "%s", qPrintable(output));
@@ -69,14 +65,13 @@ bool Helper::loadEcSysModule() const {
 int main(int argc, char *argv[]) {
     QCoreApplication a(argc, argv);
 
-    QObject obj;
-    auto *helper = new Helper(&obj);
-    QObject::connect(&a, &QCoreApplication::aboutToQuit, helper, &Helper::aboutToQuit);
+    DBusContextObject obj;
+    auto *helper = new Helper(obj);
     helper->setProperty("value", "initial value");
     QDBusConnection::systemBus().registerObject("/", &obj);
 
-    QObject objMsiEc;
-    auto *helperMsiEc = new MsiEc(&objMsiEc);
+    DBusContextObject objMsiEc;
+    auto *helperMsiEc = new MsiEc(objMsiEc);
     QDBusConnection::systemBus().registerObject("/msi_ec", &objMsiEc);
 
     if (!QDBusConnection::systemBus().registerService(SERVICE_NAME)) {

--- a/src/helper/helper.h
+++ b/src/helper/helper.h
@@ -31,15 +31,13 @@ class Helper : public QDBusAbstractAdaptor {
 Q_OBJECT
     Q_CLASSINFO("D-Bus Interface", INTERFACE_NAME)
 public:
-    explicit Helper(QObject *obj) : QDBusAbstractAdaptor(obj) {}
+    explicit Helper(DBusContextObject &obj) : QDBusAbstractAdaptor(&obj), context(obj) {}
 
-signals:
-    void aboutToQuit();
+private:
+    DBusContextObject &context;
 
 public slots:
-    Q_NOREPLY void quit() const;
     [[nodiscard]] QByteArray getData() const;
-    Q_NOREPLY void putValue(const int &address, const int &value) const;
     [[nodiscard]] bool isEcSysModuleLoaded() const;
     [[nodiscard]] bool loadEcSysModule() const;
 };

--- a/src/helper/mcontrolcenter-helper.conf
+++ b/src/helper/mcontrolcenter-helper.conf
@@ -20,6 +20,9 @@
 -->
 
 <busconfig>
+        <!-- Read-only diagnostics are available to local desktop callers.
+             Every mutating adaptor method performs a PolicyKit check using the
+             authenticated unique bus name before touching hardware. -->
         <policy user="root">
                 <allow own="mcontrolcenter.helper"/>
                 <allow send_destination="mcontrolcenter.helper"/>

--- a/src/helper/msi-ec.cpp
+++ b/src/helper/msi-ec.cpp
@@ -17,7 +17,9 @@
  */
 
 #include "msi-ec.h"
+#include "authorization.h"
 #include <QFile>
+#include <utility>
 
 // Available entries: https://github.com/BeardOverflow/msi-ec?tab=readme-ov-file#usage
 const QString msi_ec_path = "/sys/devices/platform/msi-ec";
@@ -46,6 +48,10 @@ const QString msi_ec_bat1_status = msi_ec_bat1 + "/status";
 // /sys/class/leds/platform::<led_name>/brightness
 const QString msi_ec_kbd_backlight_brightness = "/sys/class/leds/msiacpi::kbd_backlight/brightness";
 
+MsiEc::MsiEc(DBusContextObject &parent, QString sysfsRoot)
+    : QDBusAbstractAdaptor(&parent), context(parent),
+      fanCurveBackend(sysfsRoot.isEmpty() ? QStringLiteral("/sys/devices/platform/msi-ec") : std::move(sysfsRoot)) {}
+
 QString MsiEc::readFile(QString path) const {
     if (QFile file(path); file.exists() && file.open(QIODevice::ReadOnly)) {
         // Remove only the last '\n'
@@ -58,10 +64,12 @@ bool MsiEc::readFileOnOff(QString path) const {
     return readFile(path) == "on";
 }
 
-void MsiEc::writeFile(QString path, QString value) const {
-    if (QFile file(path); file.exists() && file.open(QIODevice::WriteOnly)) {
-        file.write(value.toUtf8());
-    }
+bool MsiEc::writeFile(QString path, QString value) const {
+    if (!authorizeHardwareMutation(context.callContext()))
+        return false;
+    if (QFile file(path); file.exists() && file.open(QIODevice::WriteOnly))
+        return file.write(value.toUtf8()) == value.toUtf8().size();
+    return false;
 }
 
 void MsiEc::writeFileOnOff(QString path, bool on) const {
@@ -108,8 +116,12 @@ bool MsiEc::hasFnKey() const {
 QString MsiEc::getFnKey() const {
     return readFile(msi_ec_fn_key);
 }
-void MsiEc::setFnKey(QString side) const {
-    writeFile(msi_ec_fn_key, side);
+bool MsiEc::setFnKey(QString side) const {
+    if (side != QStringLiteral("left") && side != QStringLiteral("right")) {
+        context.sendCallError(QDBusError::InvalidArgs, QStringLiteral("invalid Fn key side"));
+        return false;
+    }
+    return writeFile(msi_ec_fn_key, side);
 }
 
 //////////////// win_key ////////////////
@@ -137,8 +149,10 @@ bool MsiEc::getFnWinSwap() const {
     // (e.g. with a file fn_win_swap)
     return getFnKey() == "left";
 }
-void MsiEc::setFnWinSwap(bool swap) const {
-    setFnKey(swap ? "left" : "right");
+bool MsiEc::setFnWinSwap(bool swap) const {
+    if (!setFnKey(swap ? QStringLiteral("left") : QStringLiteral("right")))
+        return false;
+    return getFnWinSwap() == swap;
 }
 
 //////////////// cooler_boost ////////////////
@@ -164,8 +178,15 @@ QString MsiEc::getAvailableShiftModes() const {
 QString MsiEc::getShiftMode() const {
     return readFile(msi_ec_shift_mode);
 }
-void MsiEc::setShiftMode(QString mode) const {
-    writeFile(msi_ec_shift_mode, mode);
+bool MsiEc::setShiftMode(QString mode) const {
+    if (mode != QStringLiteral("eco") && mode != QStringLiteral("comfort") &&
+        mode != QStringLiteral("sport") && mode != QStringLiteral("turbo")) {
+        context.sendCallError(QDBusError::InvalidArgs, QStringLiteral("invalid shift mode"));
+        return false;
+    }
+    if (!writeFile(msi_ec_shift_mode, mode))
+        return false;
+    return getShiftMode() == mode;
 }
 
 //////////////// super_battery ////////////////
@@ -176,8 +197,10 @@ bool MsiEc::hasSuperBattery() const {
 bool MsiEc::getSuperBattery() const {
     return readFileOnOff(msi_ec_super_battery);
 }
-void MsiEc::setSuperBattery(bool enable) const {
-    writeFileOnOff(msi_ec_super_battery, enable);
+bool MsiEc::setSuperBattery(bool enable) const {
+    if (!writeFile(msi_ec_super_battery, enable ? QStringLiteral("on") : QStringLiteral("off")))
+        return false;
+    return getSuperBattery() == enable;
 }
 
 //////////////// fan_mode ////////////////
@@ -191,8 +214,67 @@ QString MsiEc::getAvailableFanModes() const {
 QString MsiEc::getFanMode() const {
     return readFile(msi_ec_fan_mode);
 }
-void MsiEc::setFanMode(QString mode) const {
-    writeFile(msi_ec_fan_mode, mode);
+bool MsiEc::setFanMode(QString mode) const {
+    // Reject malformed requests before any PolicyKit invocation. An invalid
+    // D-Bus call must not trigger authentication UI or consume the helper's
+    // authorization timeout.
+    if (mode != QStringLiteral("auto") && mode != QStringLiteral("silent") &&
+        mode != QStringLiteral("basic") && mode != QStringLiteral("advanced")) {
+        context.sendCallError(QDBusError::InvalidArgs, QStringLiteral("invalid fan mode"));
+        return false;
+    }
+    if (!authorizeHardwareMutation(context.callContext())) {
+        context.sendCallError(QDBusError::AccessDenied,
+                              QStringLiteral("PolicyKit authorization required"));
+        return false;
+    }
+    QString error;
+    if (!writeFanModeVerified(fanCurveBackend, mode, &error))
+        return false;
+    return true;
+}
+
+//////////////// fan curve ////////////////
+
+QVariantMap MsiEc::getFanCurveCapability() const {
+    return fanCurveCapabilityToMap(fanCurveBackend.capability());
+}
+
+QVariantMap MsiEc::getFanCurveProfile() const {
+    FanCurveProfile profile;
+    QString error;
+    const FanCurveCapability capability = fanCurveBackend.capability();
+    if (!capability.complete() || !fanCurveBackend.readProfile(&profile, &error))
+        return {{QStringLiteral("readable"), false}, {QStringLiteral("error"), error}};
+    // Readability is distinct from strict validity. A complete device profile
+    // remains available for repair even when values are out of range or badly
+    // ordered; Apply performs the strict validation.
+    QVariantMap result = fanCurveProfileToMap(profile);
+    result.insert(QStringLiteral("readable"), true);
+    result.insert(QStringLiteral("valid"), validateFanCurve(capability, profile).isEmpty());
+    if (const QString validationError = validateFanCurve(capability, profile); !validationError.isEmpty())
+        result.insert(QStringLiteral("error"), validationError);
+    return result;
+}
+
+QVariantMap MsiEc::applyFanCurveTransaction(const QVariantMap &profileMap) const {
+    if (!authorizeHardwareMutation(context.callContext())) {
+        FanCurveResult denied;
+        denied.error = QStringLiteral("PolicyKit authorization required");
+        denied.rollbackStatus = QStringLiteral("not-attempted");
+        denied.effectiveMode = fanCurveBackend.readMode();
+        return fanCurveResultToMap(denied);
+    }
+    FanCurveProfile profile;
+    FanCurveResult result;
+    if (!fanCurveProfileFromMap(profileMap, &profile)) {
+        result.error = QStringLiteral("malformed fan curve profile");
+        result.effectiveMode = fanCurveBackend.readMode();
+        result.rollbackStatus = QStringLiteral("not-attempted");
+        return fanCurveResultToMap(result);
+    }
+    FanCurveTransaction transaction(fanCurveBackend);
+    return fanCurveResultToMap(transaction.apply(profile));
 }
 
 //////////////// fw_version ////////////////
@@ -217,7 +299,7 @@ int MsiEc::getCPURealtimeTemperature() const {
     return readFile(msi_ec_cpu_realtime_temperature).toInt();
 }
 
-// cpu/realtime_fan_speed 0-100 (percent)
+// cpu/realtime_fan_speed: driver-reported fan level (not RPM)
 bool MsiEc::hasCPURealtimeFanSpeed() const {
     return QFile::exists(msi_ec_cpu_realtime_fan_speed);
 }
@@ -246,7 +328,7 @@ int MsiEc::getGPURealtimeTemperature() const {
     return readFile(msi_ec_gpu_realtime_temperature).toInt();
 }
 
-// gpu/realtime_fan_speed 0-100 (percent)
+// gpu/realtime_fan_speed: driver-reported fan level (not RPM)
 bool MsiEc::hasGPURealtimeFanSpeed() const {
     return QFile::exists(msi_ec_gpu_realtime_fan_speed);
 }

--- a/src/helper/msi-ec.h
+++ b/src/helper/msi-ec.h
@@ -24,6 +24,7 @@
 #include <QtCore/QObject>
 #include <QtDBus/QDBusAbstractAdaptor>
 #include <QtDBus/QDBusVariant>
+#include "fan-curve.h"
 
 /**
  * Interface for [msi-ec by BeardOverflow](https://github.com/BeardOverflow/msi-ec/)
@@ -32,12 +33,14 @@ class MsiEc : public QDBusAbstractAdaptor {
     Q_OBJECT
     Q_CLASSINFO("D-Bus Interface", INTERFACE_NAME_MSI_EC)
 public:
-    explicit MsiEc(QObject *parent) : QDBusAbstractAdaptor(parent) {}
+    explicit MsiEc(DBusContextObject &parent, QString sysfsRoot = {});
 
 private:
+    DBusContextObject &context;
+    mutable SysfsFanCurveBackend fanCurveBackend;
     QString readFile(QString path) const;
     bool readFileOnOff(QString path) const;
-    void writeFile(QString path, QString value) const;
+    bool writeFile(QString path, QString value) const;
     void writeFileOnOff(QString path, bool on) const;
 
 public slots:
@@ -56,7 +59,7 @@ public slots:
     // fn_key left/right
     [[nodiscard]] bool hasFnKey() const;
     [[nodiscard]] QString getFnKey() const;
-    Q_NOREPLY void setFnKey(QString side) const;
+    [[nodiscard]] bool setFnKey(QString side) const;
     // win_key left/right
     [[nodiscard]] bool hasWinKey() const;
     [[nodiscard]] QString getWinKey() const;
@@ -64,7 +67,7 @@ public slots:
     // fn_win_swap swap/no swap
     [[nodiscard]] bool hasFnWinSwap() const;
     [[nodiscard]] bool getFnWinSwap() const;
-    Q_NOREPLY void setFnWinSwap(bool swap) const;
+    [[nodiscard]] bool setFnWinSwap(bool swap) const;
 
     // cooler_boost
     [[nodiscard]] bool hasCoolerBoost() const;
@@ -75,18 +78,23 @@ public slots:
     [[nodiscard]] bool hasShiftMode() const;
     [[nodiscard]] QString getAvailableShiftModes() const;
     [[nodiscard]] QString getShiftMode() const;
-    Q_NOREPLY void setShiftMode(QString mode) const;
+    [[nodiscard]] bool setShiftMode(QString mode) const;
 
     // super_battery
     [[nodiscard]] bool hasSuperBattery() const;
     [[nodiscard]] bool getSuperBattery() const;
-    Q_NOREPLY void setSuperBattery(bool enable) const;
+    [[nodiscard]] bool setSuperBattery(bool enable) const;
 
     // fan_mode & available_fan_modes
     [[nodiscard]] bool hasFanMode() const;
     [[nodiscard]] QString getAvailableFanModes() const;
     [[nodiscard]] QString getFanMode() const;
-    Q_NOREPLY void setFanMode(QString mode) const;
+    [[nodiscard]] bool setFanMode(QString mode) const;
+
+    // Complete fan-curve ABI. Advanced mode alone is not sufficient.
+    [[nodiscard]] QVariantMap getFanCurveCapability() const;
+    [[nodiscard]] QVariantMap getFanCurveProfile() const;
+    [[nodiscard]] QVariantMap applyFanCurveTransaction(const QVariantMap &profile) const;
 
     // fw_version
     [[nodiscard]] QString getFWVersion() const;
@@ -96,7 +104,7 @@ public slots:
     // cpu/realtime_temperature 0-100 (celsius scale)
     [[nodiscard]] bool hasCPURealtimeTemperature() const;
     [[nodiscard]] int getCPURealtimeTemperature() const;
-    // cpu/realtime_fan_speed 0-100 (percent)
+    // cpu/realtime_fan_speed: driver-reported fan level (not RPM)
     [[nodiscard]] bool hasCPURealtimeFanSpeed() const;
     [[nodiscard]] int getCPURealtimeFanSpeed() const;
     // cpu/basic_fan_speed 0-100 (percent)
@@ -107,7 +115,7 @@ public slots:
     // gpu/realtime_temperature 0-100 (celsius scale)
     [[nodiscard]] bool hasGPURealtimeTemperature() const;
     [[nodiscard]] int getGPURealtimeTemperature() const;
-    // gpu/realtime_fan_speed 0-100 (percent)
+    // gpu/realtime_fan_speed: driver-reported fan level (not RPM)
     [[nodiscard]] bool hasGPURealtimeFanSpeed() const;
     [[nodiscard]] int getGPURealtimeFanSpeed() const;
 

--- a/src/helper/org.mcontrolcenter.fan-control.policy
+++ b/src/helper/org.mcontrolcenter.fan-control.policy
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
+<policyconfig>
+  <action id="org.mcontrolcenter.fan-control">
+    <description>Control MControlCenter fan curves and supported hardware settings</description>
+    <message>Authentication is required to change hardware fan settings.</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/libexec/mcontrolcenter-helper</annotate>
+  </action>
+</policyconfig>

--- a/src/helper/readwrite.cpp
+++ b/src/helper/readwrite.cpp
@@ -17,8 +17,6 @@
  */
 
 #include "readwrite.h"
-#include <fstream>
-
 #include <QFile>
 
 const QString acpi_ec_file = "/dev/ec";
@@ -31,14 +29,6 @@ QByteArray ReadWrite::readFromFile() const {
     if (QFile file(ioFile); file.open(QIODevice::ReadOnly))
         return file.readAll();
     return {};
-}
-
-void ReadWrite::writeToFile(const int pos, BYTE value) const {
-    std::ofstream file(ioFile.toStdString(), std::ios::in | std::ios::out | std::ios::binary);
-    if (file.is_open()) {
-        file.seekp(pos);
-        file << value;
-    }
 }
 
 bool ReadWrite::isAcpiEc() const {

--- a/src/helper/readwrite.h
+++ b/src/helper/readwrite.h
@@ -26,7 +26,6 @@ class ReadWrite {
 public:
     ReadWrite();
     QByteArray readFromFile() const;
-    void writeToFile(int pos, BYTE value) const;
     bool isAcpiEc() const;
     bool isEcSys() const;
 };

--- a/src/helper/service.h
+++ b/src/helper/service.h
@@ -16,6 +16,33 @@
  * with MControlCenter. If not, see <https://www.gnu.org/licenses/>.
  */
 
+#ifndef MCONTROL_CENTER_SERVICE_H
+#define MCONTROL_CENTER_SERVICE_H
+
+#include <QObject>
+#include <QtDBus/QDBusContext>
+#include <QtDBus/QDBusError>
+
 #define SERVICE_NAME "mcontrolcenter.helper"
 #define INTERFACE_NAME "dmitry_s93.MControlCenter"
 #define INTERFACE_NAME_MSI_EC "BeardOverflow.msi_ec"
+
+// Qt attaches QDBusContext to the QObject registered with registerObject(),
+// not to a QDBusAbstractAdaptor attached to that object. Adaptors must use
+// this registered owner's context for caller identity and error replies.
+class DBusContextObject final : public QObject, protected QDBusContext {
+    Q_OBJECT
+public:
+    explicit DBusContextObject(QObject *parent = nullptr) : QObject(parent) {}
+
+    [[nodiscard]] const QDBusContext &callContext() const noexcept { return *this; }
+
+    bool sendCallError(QDBusError::ErrorType type, const QString &message) const {
+        if (!calledFromDBus())
+            return false;
+        sendErrorReply(type, message);
+        return true;
+    }
+};
+
+#endif // MCONTROL_CENTER_SERVICE_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -22,6 +22,8 @@
 #include "settings.h"
 #include <QTimer>
 #include <QMessageBox>
+#include <QSignalBlocker>
+#include <QDBusConnection>
 
 Operate operate;
 PowerMonitor powerMonitor;
@@ -38,31 +40,31 @@ MainWindow::MainWindow(QWidget *parent)
     connect(ui->advancedFanControlCheckBox, &QCheckBox::toggled, this, &MainWindow::setFanModeAdvanced);
 
     connect(ui->fan1Speed1Slider, &QSlider::valueChanged, this, [this]() {
-        ui->fan1Speed1Label->setText(QString("%1%").arg(ui->fan1Speed1Slider->value()));
+        ui->fan1Speed1Label->setText(QString(tr("fan level %1")).arg(ui->fan1Speed1Slider->value()));
         checkFanSettingsChanged();
     });
     connect(ui->fan1Speed2Slider, &QSlider::valueChanged, this, [this]() {
-        ui->fan1Speed2Label->setText(QString("%1%").arg(ui->fan1Speed2Slider->value()));
+        ui->fan1Speed2Label->setText(QString(tr("fan level %1")).arg(ui->fan1Speed2Slider->value()));
         checkFanSettingsChanged();
     });
     connect(ui->fan1Speed3Slider, &QSlider::valueChanged, this, [this]() {
-        ui->fan1Speed3Label->setText(QString("%1%").arg(ui->fan1Speed3Slider->value()));
+        ui->fan1Speed3Label->setText(QString(tr("fan level %1")).arg(ui->fan1Speed3Slider->value()));
         checkFanSettingsChanged();
     });
     connect(ui->fan1Speed4Slider, &QSlider::valueChanged, this, [this]() {
-        ui->fan1Speed4Label->setText(QString("%1%").arg(ui->fan1Speed4Slider->value()));
+        ui->fan1Speed4Label->setText(QString(tr("fan level %1")).arg(ui->fan1Speed4Slider->value()));
         checkFanSettingsChanged();
     });
     connect(ui->fan1Speed5Slider, &QSlider::valueChanged, this, [this]() {
-        ui->fan1Speed5Label->setText(QString("%1%").arg(ui->fan1Speed5Slider->value()));
+        ui->fan1Speed5Label->setText(QString(tr("fan level %1")).arg(ui->fan1Speed5Slider->value()));
         checkFanSettingsChanged();
     });
     connect(ui->fan1Speed6Slider, &QSlider::valueChanged, this, [this]() {
-        ui->fan1Speed6Label->setText(QString("%1%").arg(ui->fan1Speed6Slider->value()));
+        ui->fan1Speed6Label->setText(QString(tr("fan level %1")).arg(ui->fan1Speed6Slider->value()));
         checkFanSettingsChanged();
     });
     connect(ui->fan1Speed7Slider, &QSlider::valueChanged, this, [this]() {
-        ui->fan1Speed7Label->setText(QString("%1%").arg(ui->fan1Speed7Slider->value()));
+        ui->fan1Speed7Label->setText(QString(tr("fan level %1")).arg(ui->fan1Speed7Slider->value()));
         checkFanSettingsChanged();
     });
 
@@ -87,31 +89,31 @@ MainWindow::MainWindow(QWidget *parent)
     });
 
     connect(ui->fan2Speed1Slider, &QSlider::valueChanged, this, [this]() {
-        ui->fan2Speed1Label->setText(QString("%1%").arg(ui->fan2Speed1Slider->value()));
+        ui->fan2Speed1Label->setText(QString(tr("fan level %1")).arg(ui->fan2Speed1Slider->value()));
         checkFanSettingsChanged();
     });
     connect(ui->fan2Speed2Slider, &QSlider::valueChanged, this, [this]() {
-        ui->fan2Speed2Label->setText(QString("%1%").arg(ui->fan2Speed2Slider->value()));
+        ui->fan2Speed2Label->setText(QString(tr("fan level %1")).arg(ui->fan2Speed2Slider->value()));
         checkFanSettingsChanged();
     });
     connect(ui->fan2Speed3Slider, &QSlider::valueChanged, this, [this]() {
-        ui->fan2Speed3Label->setText(QString("%1%").arg(ui->fan2Speed3Slider->value()));
+        ui->fan2Speed3Label->setText(QString(tr("fan level %1")).arg(ui->fan2Speed3Slider->value()));
         checkFanSettingsChanged();
     });
     connect(ui->fan2Speed4Slider, &QSlider::valueChanged, this, [this]() {
-        ui->fan2Speed4Label->setText(QString("%1%").arg(ui->fan2Speed4Slider->value()));
+        ui->fan2Speed4Label->setText(QString(tr("fan level %1")).arg(ui->fan2Speed4Slider->value()));
         checkFanSettingsChanged();
     });
     connect(ui->fan2Speed5Slider, &QSlider::valueChanged, this, [this]() {
-        ui->fan2Speed5Label->setText(QString("%1%").arg(ui->fan2Speed5Slider->value()));
+        ui->fan2Speed5Label->setText(QString(tr("fan level %1")).arg(ui->fan2Speed5Slider->value()));
         checkFanSettingsChanged();
     });
     connect(ui->fan2Speed6Slider, &QSlider::valueChanged, this, [this]() {
-        ui->fan2Speed6Label->setText(QString("%1%").arg(ui->fan2Speed6Slider->value()));
+        ui->fan2Speed6Label->setText(QString(tr("fan level %1")).arg(ui->fan2Speed6Slider->value()));
         checkFanSettingsChanged();
     });
     connect(ui->fan2Speed7Slider, &QSlider::valueChanged, this, [this]() {
-        ui->fan2Speed7Label->setText(QString("%1%").arg(ui->fan2Speed7Slider->value()));
+        ui->fan2Speed7Label->setText(QString(tr("fan level %1")).arg(ui->fan2Speed7Slider->value()));
         checkFanSettingsChanged();
     });
 
@@ -159,8 +161,10 @@ MainWindow::MainWindow(QWidget *parent)
                                                                "Check the <About> page for more info."));
     }
 
-    if (!operate.isEcSysModuleLoaded() && !operate.loadEcSysModule())
-        QMessageBox::critical(nullptr, this->windowTitle(), tr("The ec_sys module couldn't be detected, it might be required to control the fans."));
+    // ec_sys/acpi_ec is optional read-only RPM diagnostics. Never autoload it
+    // when typed msi_ec is already active; msi_ec-only systems stay usable.
+    if (!operate.isMsiEcLoaded() && !operate.isEcSysModuleLoaded() && !operate.loadEcSysModule())
+        QMessageBox::critical(nullptr, this->windowTitle(), tr("The optional ec_sys module couldn't be detected; raw RPM diagnostics are unavailable."));
 
 
 
@@ -170,10 +174,13 @@ MainWindow::MainWindow(QWidget *parent)
     connect(realtimeUpdateTimer, &QTimer::timeout, this, &MainWindow::realtimeUpdate);
     setUpdateInterval(1000);
 
-    // Timer to detect sleep and reapply Advanced Mode Fan if necessary
-    connect(&timerSleepWatcher, &QTimer::timeout, this, &MainWindow::timerSleepTimeout);
-    timerSleepWatcher.setInterval(10 * 1000);
-    timerSleepWatcher.start();
+    // logind emits this signal across suspend/resume; timer-gap heuristics can
+    // miss short sleeps and do not identify firmware changes.
+    QDBusConnection::systemBus().connect(QStringLiteral("org.freedesktop.login1"),
+                                         QStringLiteral("/org/freedesktop/login1"),
+                                         QStringLiteral("org.freedesktop.login1.Manager"),
+                                         QStringLiteral("PrepareForSleep"), this,
+                                         SLOT(onPrepareForSleep(bool)));
 
     ui->QtVersionValue->setText(QT_VERSION_STR);
     ui->versionValueLabel->setText(MControlCenter_VERSION);
@@ -218,12 +225,14 @@ void MainWindow::setUpdateInterval(int msec) const {
 }
 
 void MainWindow::realtimeUpdate() {
-    operate.updateEcDataAsync();
+    // Do not issue raw EC reads when ec_sys/acpi_ec is absent.
+    if (operate.isEcSysModuleLoaded())
+        operate.updateEcDataAsync();
     updateData();
 }
 
 void MainWindow::updateData() {
-    if (!isUpdateDataError && (operate.isMsiEcLoaded() || operate.isEcSysModuleLoaded())) {
+    if (operate.isMsiEcLoaded() || (!isUpdateDataError && operate.isEcSysModuleLoaded())) {
         if (!isActive) {
             operate.doProbe();
             setTabsEnabled(true);
@@ -256,9 +265,15 @@ void MainWindow::loadConfigs() {
     ui->ecVersionValueLabel->setText(QString::fromStdString(operate.getEcVersion()));
     ui->ecBuildValueLabel->setText(QString::fromStdString(operate.getEcBuild()));
 
-    operate.loadSettings();
+    const auto restoreResult = operate.loadSettings();
     updateUserMode();
-    updateCoolerBoostState();
+    if (operate.isCoolerBoostSupport())
+        updateCoolerBoostState();
+    else {
+        ui->coolerBoostCheckBox->setEnabled(false);
+        if (coolerBoostAction)
+            coolerBoostAction->setEnabled(false);
+    }
 
     if (operate.isBatteryThresholdSupport()) {
         updateBatteryThreshold();
@@ -269,6 +284,8 @@ void MainWindow::loadConfigs() {
     }
 
     updateFanSpeedSettings();
+    if (restoreResult.has_value() && !restoreResult->success)
+        ui->fanCurveStatusLabel->setText(tr("Failed to restore fan preference: %1").arg(restoreResult->error));
 
     if (operate.isKeyboardBacklightModeSupport()) {
         updateKeyboardBacklightMode();
@@ -295,7 +312,10 @@ void MainWindow::loadConfigs() {
         ui->webCamCheckBox->setEnabled(false);
     }
 
-    updateFnSuperSwapState();
+    if (operate.isFnSuperSwapSupport())
+        updateFnSuperSwapState();
+    else
+        ui->fnSuperSwapCheckBox->setEnabled(false);
 }
 
 QString MainWindow::intToQString(int value) const {
@@ -316,26 +336,31 @@ void MainWindow::updateBatteryThreshold() {
         else
             ui->batteryThresholdValueLabel->setText(QString::number(batteryThreshold) + " %");
 
-        switch (batteryThreshold) {
-            case 0:
-            case 100:
-                ui->bestMobilityRadioButton->click();
-                batteryThreshold = 100;
-                break;
-            case 60:
-                ui->bestBatteryRadioButton->click();
-                break;
-            case 80:
-                ui->balancedBatteryRadioButton->click();
-                break;
-            default:
-                ui->customBatteryThresholdRadioButton->click();
-                ui->customBatteryApplyButton->setEnabled(
-                        batteryThreshold != ui->customBatteryThresholdSpinBox->value());
-                break;
+        {
+            const QSignalBlocker bestMobilityBlocker(ui->bestMobilityRadioButton);
+            const QSignalBlocker bestBatteryBlocker(ui->bestBatteryRadioButton);
+            const QSignalBlocker balancedBatteryBlocker(ui->balancedBatteryRadioButton);
+            const QSignalBlocker customBlocker(ui->customBatteryThresholdRadioButton);
+            switch (batteryThreshold) {
+                case 0:
+                case 100:
+                    ui->bestMobilityRadioButton->setChecked(true);
+                    batteryThreshold = 100;
+                    break;
+                case 60:
+                    ui->bestBatteryRadioButton->setChecked(true);
+                    break;
+                case 80:
+                    ui->balancedBatteryRadioButton->setChecked(true);
+                    break;
+                default:
+                    ui->customBatteryThresholdRadioButton->setChecked(true);
+                    ui->customBatteryApplyButton->setEnabled(
+                            batteryThreshold != ui->customBatteryThresholdSpinBox->value());
+                    break;
+            }
+            ui->customBatteryThresholdSpinBox->setValue(batteryThreshold);
         }
-
-        ui->customBatteryThresholdSpinBox->setValue(batteryThreshold);
     }
 }
 
@@ -381,9 +406,11 @@ void MainWindow::updateGpuTemp() {
 }
 
 void MainWindow::updateFan1Speed() {
-    int speed = operate.getFan1Speed();
-    if (speed != 0)
-        ui->fan1ValueLabel->setText(intToQString(speed) + " " + tr("rpm"));
+    const std::optional<int> speed = operate.getFan1Speed();
+    if (!speed.has_value())
+        ui->fan1ValueLabel->setText(tr("Unavailable"));
+    else if (speed.value() != 0)
+        ui->fan1ValueLabel->setText(intToQString(speed.value()) + " " + tr("rpm"));
     else
         ui->fan1ValueLabel->setText(tr("OFF"));
 }
@@ -431,21 +458,25 @@ void MainWindow::updateCoolerBoostState() const {
 
 void MainWindow::updateUserMode() {
     if (operate.updateEcData()) {
+        const QSignalBlocker balancedBlocker(ui->balancedModeRadioButton);
+        const QSignalBlocker performanceBlocker(ui->highPerformanceModeRadioButton);
+        const QSignalBlocker silentBlocker(ui->silentModeRadioButton);
+        const QSignalBlocker superBatteryBlocker(ui->superBatteryModeRadioButton);
         switch (operate.getUserMode()) {
             case user_mode::balanced_mode:
-                ui->balancedModeRadioButton->click();
+                ui->balancedModeRadioButton->setChecked(true);
                 balancedMode->setChecked(true);
                 break;
             case user_mode::performance_mode:
-                ui->highPerformanceModeRadioButton->click();
+                ui->highPerformanceModeRadioButton->setChecked(true);
                 highPerformanceMode->setChecked(true);
                 break;
             case user_mode::silent_mode:
-                ui->silentModeRadioButton->click();
+                ui->silentModeRadioButton->setChecked(true);
                 silentMode->setChecked(true);
                 break;
             case user_mode::super_battery_mode:
-                ui->superBatteryModeRadioButton->click();
+                ui->superBatteryModeRadioButton->setChecked(true);
                 superBatteryMode->setChecked(true);
                 break;
             case user_mode::unknown_mode:
@@ -489,12 +520,84 @@ void MainWindow::updateFanMode() {
 }
 
 void MainWindow::updateFanSpeedSettings() {
+    const FanCurveCapability capability = operate.getFanCurveCapability();
+    const bool curveSupported = capability.complete();
+    ui->advancedFanControlCheckBox->setEnabled(curveSupported);
+    ui->advancedFanControlCheckBox->setToolTip(
+        curveSupported ? tr("Uses the complete msi-ec fan curve ABI")
+                       : tr("Fan curves are unavailable: the driver does not expose the complete verified ABI"));
+    // Editing is allowed in Auto as well: a malformed existing curve must be
+    // repairable before Advanced is activated by the transaction.
+    ui->fanControlTabWidget->setEnabled(curveSupported);
+    if (!curveSupported) {
+        ui->fanCurveStatusLabel->setText(
+            tr("Unsupported: complete msi-ec fan curve ABI is unavailable"));
+        ui->fanSpeedApplyButton->setEnabled(false);
+        ui->fanSpeedResetButton->setEnabled(false);
+        return;
+    }
+    for (QSlider *slider : {ui->fan1Speed1Slider, ui->fan1Speed2Slider, ui->fan1Speed3Slider,
+                            ui->fan1Speed4Slider, ui->fan1Speed5Slider, ui->fan1Speed6Slider,
+                            ui->fan1Speed7Slider, ui->fan2Speed1Slider, ui->fan2Speed2Slider,
+                            ui->fan2Speed3Slider, ui->fan2Speed4Slider, ui->fan2Speed5Slider,
+                            ui->fan2Speed6Slider, ui->fan2Speed7Slider})
+        slider->setRange(capability.levelMin, capability.levelMax);
+    for (QSpinBox *spin : {ui->fan1Speed2TempSpinBox, ui->fan1Speed3TempSpinBox,
+                           ui->fan1Speed4TempSpinBox, ui->fan1Speed5TempSpinBox,
+                           ui->fan1Speed6TempSpinBox, ui->fan1Speed7TempSpinBox,
+                           ui->fan2Speed2TempSpinBox, ui->fan2Speed3TempSpinBox,
+                           ui->fan2Speed4TempSpinBox, ui->fan2Speed5TempSpinBox,
+                           ui->fan2Speed6TempSpinBox, ui->fan2Speed7TempSpinBox})
+        spin->setRange(capability.thresholdMin, capability.thresholdMax);
+
+    const QSignalBlocker advancedBlocker(ui->advancedFanControlCheckBox);
+    const QSignalBlocker fan1Slider1Blocker(ui->fan1Speed1Slider);
+    const QSignalBlocker fan1Slider2Blocker(ui->fan1Speed2Slider);
+    const QSignalBlocker fan1Slider3Blocker(ui->fan1Speed3Slider);
+    const QSignalBlocker fan1Slider4Blocker(ui->fan1Speed4Slider);
+    const QSignalBlocker fan1Slider5Blocker(ui->fan1Speed5Slider);
+    const QSignalBlocker fan1Slider6Blocker(ui->fan1Speed6Slider);
+    const QSignalBlocker fan1Slider7Blocker(ui->fan1Speed7Slider);
+    const QSignalBlocker fan2Slider1Blocker(ui->fan2Speed1Slider);
+    const QSignalBlocker fan2Slider2Blocker(ui->fan2Speed2Slider);
+    const QSignalBlocker fan2Slider3Blocker(ui->fan2Speed3Slider);
+    const QSignalBlocker fan2Slider4Blocker(ui->fan2Speed4Slider);
+    const QSignalBlocker fan2Slider5Blocker(ui->fan2Speed5Slider);
+    const QSignalBlocker fan2Slider6Blocker(ui->fan2Speed6Slider);
+    const QSignalBlocker fan2Slider7Blocker(ui->fan2Speed7Slider);
+    const QSignalBlocker fan1Temp2Blocker(ui->fan1Speed2TempSpinBox);
+    const QSignalBlocker fan1Temp3Blocker(ui->fan1Speed3TempSpinBox);
+    const QSignalBlocker fan1Temp4Blocker(ui->fan1Speed4TempSpinBox);
+    const QSignalBlocker fan1Temp5Blocker(ui->fan1Speed5TempSpinBox);
+    const QSignalBlocker fan1Temp6Blocker(ui->fan1Speed6TempSpinBox);
+    const QSignalBlocker fan1Temp7Blocker(ui->fan1Speed7TempSpinBox);
+    const QSignalBlocker fan2Temp2Blocker(ui->fan2Speed2TempSpinBox);
+    const QSignalBlocker fan2Temp3Blocker(ui->fan2Speed3TempSpinBox);
+    const QSignalBlocker fan2Temp4Blocker(ui->fan2Speed4TempSpinBox);
+    const QSignalBlocker fan2Temp5Blocker(ui->fan2Speed5TempSpinBox);
+    const QSignalBlocker fan2Temp6Blocker(ui->fan2Speed6TempSpinBox);
+    const QSignalBlocker fan2Temp7Blocker(ui->fan2Speed7TempSpinBox);
     ui->advancedFanControlCheckBox->setChecked(operate.getFanMode() == fan_mode::advanced_fan_mode);
 
-    QVector fan1SpeedSettings = operate.getFan1SpeedSettings();
-    QVector fan1TempSettings = operate.getFan1TempSettings();
-    QVector fan2SpeedSettings = operate.getFan2SpeedSettings();
-    QVector fan2TempSettings = operate.getFan2TempSettings();
+    const auto currentProfile = operate.getFanCurveProfile();
+    if (!currentProfile.has_value()) {
+        ui->fanCurveStatusLabel->setText(tr("Failed: driver fan curve readback is unavailable"));
+        ui->fanSpeedApplyButton->setEnabled(false);
+        ui->fanSpeedResetButton->setEnabled(false);
+        return;
+    }
+    const bool currentCurveValid = validateFanCurve(capability, *currentProfile).isEmpty();
+    const QVector<int> fan1SpeedSettings = currentProfile->cpuLevels;
+    const QVector<int> fan1TempSettings = currentProfile->cpuThresholds;
+    const QVector<int> fan2SpeedSettings = currentProfile->gpuLevels;
+    const QVector<int> fan2TempSettings = currentProfile->gpuThresholds;
+    if (fan1SpeedSettings.size() != 7 || fan2SpeedSettings.size() != 7 ||
+        fan1TempSettings.size() != 6 || fan2TempSettings.size() != 6) {
+        ui->fanCurveStatusLabel->setText(tr("Failed: driver fan curve readback is unavailable"));
+        ui->fanSpeedApplyButton->setEnabled(false);
+        ui->fanSpeedResetButton->setEnabled(false);
+        return;
+    }
 
     ui->fan1Speed1Slider->setValue(fan1SpeedSettings[0]);
     ui->fan1Speed2Slider->setValue(fan1SpeedSettings[1]);
@@ -529,6 +632,11 @@ void MainWindow::updateFanSpeedSettings() {
     ui->fan2Speed7TempSpinBox->setValue(fan2TempSettings[5]);
 
     checkFanSettingsChanged();
+    if (!currentCurveValid) {
+        ui->fanCurveStatusLabel->setText(
+            tr("Warning: current driver curve has an invalid range or ordering; repair it before applying"));
+        ui->fanSpeedApplyButton->setEnabled(true);
+    }
 }
 
 void MainWindow::setBestMobility() {
@@ -546,24 +654,79 @@ void MainWindow::setBestBattery() {
     updateBatteryThreshold();
 }
 
+namespace {
+void showModeResult(const std::optional<FanCurveResult> &result, QLabel *statusLabel,
+                    const QString &actualMode) {
+    if (!result.has_value()) {
+        statusLabel->setText(QObject::tr("Mode applied: %1").arg(actualMode));
+    } else if (result->success) {
+        statusLabel->setText(result->effectiveMode == QStringLiteral("advanced")
+                                 ? QObject::tr("Applied (advanced)")
+                                 : QObject::tr("Mode applied: %1").arg(result->effectiveMode));
+    } else {
+        statusLabel->setText(QObject::tr("Failed to reconcile fan preference: %1").arg(result->error));
+    }
+}
+}
+
 void MainWindow::setHighPerformanceMode() {
-    operate.setUserMode(user_mode::performance_mode);
+    const bool modeOk = operate.setUserMode(user_mode::performance_mode);
     updateUserMode();
+    updateFanMode();
+    if (!modeOk) {
+        ui->fanCurveStatusLabel->setText(tr("Failed to verify Performance mode; pending fan edits preserved"));
+        return;
+    }
+    const auto result = operate.reconcileFanCurvePreference();
+    updateFanMode();
+    showModeResult(result, ui->fanCurveStatusLabel, ui->fanModeValueLabel->text());
+    if (!result.has_value() || result->success)
+        updateFanSpeedSettings();
 }
 
 void MainWindow::setBalancedMode() {
-    operate.setUserMode(user_mode::balanced_mode);
+    const bool modeOk = operate.setUserMode(user_mode::balanced_mode);
     updateUserMode();
+    updateFanMode();
+    if (!modeOk) {
+        ui->fanCurveStatusLabel->setText(tr("Failed to verify Balanced mode; pending fan edits preserved"));
+        return;
+    }
+    const auto result = operate.reconcileFanCurvePreference();
+    updateFanMode();
+    showModeResult(result, ui->fanCurveStatusLabel, ui->fanModeValueLabel->text());
+    if (!result.has_value() || result->success)
+        updateFanSpeedSettings();
 }
 
 void MainWindow::setSilentMode() {
-    operate.setUserMode(user_mode::silent_mode);
+    const bool modeOk = operate.setUserMode(user_mode::silent_mode);
     updateUserMode();
+    updateFanMode();
+    if (!modeOk) {
+        ui->fanCurveStatusLabel->setText(tr("Failed to verify Silent mode; pending fan edits preserved"));
+        return;
+    }
+    const auto result = operate.reconcileFanCurvePreference();
+    updateFanMode();
+    showModeResult(result, ui->fanCurveStatusLabel, ui->fanModeValueLabel->text());
+    if (!result.has_value() || result->success)
+        updateFanSpeedSettings();
 }
 
 void MainWindow::setSuperBatteryMode() {
-    operate.setUserMode(user_mode::super_battery_mode);
+    const bool modeOk = operate.setUserMode(user_mode::super_battery_mode);
     updateUserMode();
+    updateFanMode();
+    if (!modeOk) {
+        ui->fanCurveStatusLabel->setText(tr("Failed to verify Super Battery mode; pending fan edits preserved"));
+        return;
+    }
+    const auto result = operate.reconcileFanCurvePreference();
+    updateFanMode();
+    showModeResult(result, ui->fanCurveStatusLabel, ui->fanModeValueLabel->text());
+    if (!result.has_value() || result->success)
+        updateFanSpeedSettings();
 }
 
 void MainWindow::setCoolerBoostState(bool enabled) const {
@@ -627,26 +790,96 @@ QVector<int> MainWindow::getFan2TempValues() const {
 }
 
 void MainWindow::setFanSpeedSettings() {
-    operate.setFan1SpeedSettings(getFan1SpeedValues());
-    operate.setFan1TempSettings(getFan1TempValues());
-    operate.setFan2SpeedSettings(getFan2SpeedValues());
-    operate.setFan2TempSettings(getFan2TempValues());
-    if (operate.updateEcData())
+    const FanCurveCapability capability = operate.getFanCurveCapability();
+    if (!capability.complete()) {
+        ui->fanCurveStatusLabel->setText(tr("Unsupported: complete msi-ec fan curve ABI is unavailable"));
+        return;
+    }
+    ui->fanCurveStatusLabel->setText(tr("Applying…"));
+    qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
+    FanCurveProfile profile;
+    profile.cpuLevels = getFan1SpeedValues();
+    profile.cpuThresholds = getFan1TempValues();
+    profile.gpuLevels = getFan2SpeedValues();
+    profile.gpuThresholds = getFan2TempValues();
+    const FanCurveResult result = operate.applyFanCurve(profile);
+    if (result.success) {
+        ui->fanCurveStatusLabel->setText(tr("Applied (advanced)"));
+        updateFanSpeedSettings();
+    } else {
+        // Keep the editor's pending values intact on failure while reconciling
+        // only actual mode/status.
+        {
+            const QSignalBlocker blocker(ui->advancedFanControlCheckBox);
+            ui->advancedFanControlCheckBox->setChecked(result.effectiveMode == QStringLiteral("advanced"));
+        }
+        updateFanMode();
+        ui->fanCurveStatusLabel->setText(
+            tr("Failed: %1 (rollback: %2)").arg(result.error, result.rollbackStatus));
         checkFanSettingsChanged();
+    }
 }
 
-void MainWindow::setFanModeAdvanced(bool enabled) const {
-    operate.setFanModeAdvanced(enabled);
-    ui->fanControlTabWidget->setEnabled(enabled);
+void MainWindow::setFanModeAdvanced(bool enabled) {
+    if (!operate.getFanCurveCapability().complete()) {
+        ui->fanCurveStatusLabel->setText(tr("Unsupported: complete msi-ec fan curve ABI is unavailable"));
+        return;
+    }
+    if (enabled) {
+        ui->fanCurveStatusLabel->setText(tr("Applying…"));
+        qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
+    }
+    if (!enabled) {
+        if (!operate.setFanModeAdvanced(false)) {
+            {
+                const QSignalBlocker blocker(ui->advancedFanControlCheckBox);
+                ui->advancedFanControlCheckBox->setChecked(
+                    operate.getFanMode() == fan_mode::advanced_fan_mode);
+            }
+            ui->fanCurveStatusLabel->setText(tr("Failed: could not verify Auto mode; pending fan edits preserved"));
+            updateFanMode();
+            checkFanSettingsChanged();
+            return;
+        }
+    }
+    ui->fanControlTabWidget->setEnabled(operate.getFanCurveCapability().complete());
     ui->fanSpeedResetButton->setEnabled(enabled);
     ui->fanSpeedApplyButton->setEnabled(enabled);
+    if (enabled) {
+        const FanCurveResult result = operate.applyFanCurve(
+            FanCurveProfile{getFan1TempValues(), getFan1SpeedValues(),
+                             getFan2TempValues(), getFan2SpeedValues()});
+        if (result.success) {
+            ui->fanCurveStatusLabel->setText(tr("Applied (advanced)"));
+            updateFanSpeedSettings();
+        } else {
+            const QSignalBlocker blocker(ui->advancedFanControlCheckBox);
+            ui->advancedFanControlCheckBox->setChecked(result.effectiveMode == QStringLiteral("advanced"));
+            ui->fanCurveStatusLabel->setText(
+                tr("Failed: %1 (rollback: %2); pending fan edits preserved")
+                    .arg(result.error, result.rollbackStatus));
+            checkFanSettingsChanged();
+        }
+    } else {
+        ui->fanCurveStatusLabel->setText(tr("Auto"));
+    }
 }
 
 void MainWindow::checkFanSettingsChanged() const {
-    bool fanSettingChanged = (getFan1SpeedValues() != operate.getFan1SpeedSettings() ||
-                              getFan2SpeedValues() != operate.getFan2SpeedSettings() ||
-                              getFan1TempValues() != operate.getFan1TempSettings() ||
-                              getFan2TempValues() != operate.getFan2TempSettings());
+    const FanCurveCapability capability = operate.getFanCurveCapability();
+    if (!capability.complete()) {
+        ui->fanSpeedApplyButton->setEnabled(false);
+        ui->fanSpeedResetButton->setEnabled(false);
+        return;
+    }
+    const auto currentProfile = operate.getFanCurveProfile();
+    const bool currentCurveInvalid = !currentProfile.has_value() ||
+                                     !validateFanCurve(capability, *currentProfile).isEmpty();
+    bool fanSettingChanged = currentCurveInvalid ||
+                             (getFan1SpeedValues() != currentProfile->cpuLevels ||
+                              getFan2SpeedValues() != currentProfile->gpuLevels ||
+                              getFan1TempValues() != currentProfile->cpuThresholds ||
+                              getFan2TempValues() != currentProfile->gpuThresholds);
     ui->fanSpeedApplyButton->setEnabled(fanSettingChanged);
     ui->fanSpeedResetButton->setEnabled(fanSettingChanged);
 }
@@ -667,23 +900,24 @@ void MainWindow::closeEvent(QCloseEvent *event) {
 }
 
 void MainWindow::quitApp() const {
-    operate.closeHelperApp();
     Settings::setValue("MainWindow/Width", MainWindow::width());
     Settings::setValue("MainWindow/Height", MainWindow::height());
     (void) QCoreApplication::quit();
 }
 
-void MainWindow::timerSleepTimeout() {
-    qint64 timeNow = QDateTime::currentMSecsSinceEpoch();
-    if (timeLastWatcherInterval == 0) {
-        timeLastWatcherInterval = timeNow;
+void MainWindow::onPrepareForSleep(bool sleeping) {
+    if (sleeping)
         return;
-    }
-    qint64 msecsSinceTimeout = timeNow - timeLastWatcherInterval;
-    timeLastWatcherInterval = timeNow;
-    if (msecsSinceTimeout > timerSleepWatcher.interval() + 5000) {
-        // Went to sleep for at least 5 seconds
-        operate.handleWakeEvent();
+    const auto result = operate.handleWakeEvent();
+    if (result.has_value() && !result->success) {
+        ui->fanCurveStatusLabel->setText(
+            tr("Failed to reconcile after resume: %1; pending fan edits preserved").arg(result->error));
+        updateUserMode();
+        updateFanMode();
+    } else if (result.has_value() && result->success) {
+        updateUserMode();
+        updateFanMode();
+        updateFanSpeedSettings();
     }
 }
 
@@ -730,15 +964,12 @@ void MainWindow::on_PowerProfileChange(const PowerProfile profile) {
         switch (profile) {
         case PowerProfile::Performance:
             setHighPerformanceMode();
-            ui->highPerformanceModeRadioButton->setChecked(true);
             break;
         case PowerProfile::Balanced:
             setBalancedMode();
-            ui->balancedModeRadioButton->setChecked(true);
             break;
         case PowerProfile::PowerSaver:
             setSuperBatteryMode();
-            ui->superBatteryModeRadioButton->setChecked(true);
             break;
         case PowerProfile::Unknown:
             default:;
@@ -786,12 +1017,6 @@ void MainWindow::on_ReadValueButton_clicked() {
     ui->ValueSpinBox->setValue(value);
 }
 
-void MainWindow::on_WriteValueButton_clicked() const {
-    QString text = ui->addressEdit->displayText();
-    int address = text.toInt();
-    operate.setValue(address, ui->ValueSpinBox->value());
-}
-
 void MainWindow::on_usbPowerShareCheckBox_clicked(bool checked) const {
     operate.setUsbPowerShareState(checked);
 }
@@ -804,7 +1029,11 @@ void MainWindow::on_webCamCheckBox_clicked(bool checked) const {
 }
 
 void MainWindow::on_fnSuperSwapCheckBox_clicked(bool checked) const {
-    operate.setFnSuperSwapState(checked);
+    if (operate.setFnSuperSwapState(checked))
+        return;
+    const QSignalBlocker blocker(ui->fnSuperSwapCheckBox);
+    ui->fnSuperSwapCheckBox->setChecked(operate.getFnSuperSwapState());
+    ui->fanCurveStatusLabel->setText(tr("Failed to verify Fn/Super swap; setting was not persisted"));
 }
 
 void MainWindow::on_coolerBoostCheckBox_clicked(bool checked) const {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -84,16 +84,12 @@ private:
     QVector<int> getFan1TempValues() const;
     QVector<int> getFan2TempValues() const;
     void setFanSpeedSettings();
-    void setFanModeAdvanced(bool enabled) const;
+    void setFanModeAdvanced(bool enabled);
     void checkFanSettingsChanged() const;
 
     void showEvent(QShowEvent *event);
     void closeEvent(QCloseEvent *event);
     void quitApp() const;
-
-    QTimer timerSleepWatcher;
-    qint64 timeLastWatcherInterval = 0;
-    void timerSleepTimeout();
 
     void createTrayIcon();
     void createActions();
@@ -124,7 +120,7 @@ private:
 private slots:
     void on_ChargerStateChange(bool isCharging);
     void on_PowerProfileChange(const PowerProfile profile);
-
+    void onPrepareForSleep(bool sleeping);
     void on_bestMobilityRadioButton_toggled(bool checked);
     void on_balancedBatteryRadioButton_toggled(bool checked);
     void on_bestBatteryRadioButton_toggled(bool checked);
@@ -132,8 +128,6 @@ private slots:
     void on_customBatteryThresholdSpinBox_valueChanged(int arg1);
     void on_customBatteryApplyButton_clicked();
     void on_ReadValueButton_clicked();
-
-    void on_WriteValueButton_clicked() const;
 
     void on_usbPowerShareCheckBox_clicked(bool checked) const;
     void on_webCamCheckBox_clicked(bool checked) const;

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -915,6 +915,16 @@
               </property>
              </widget>
             </item>
+            <item row="0" column="1">
+             <widget class="QLabel" name="fanCurveStatusLabel">
+              <property name="text">
+               <string>Checking fan curve capability…</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
             <item row="1" column="0">
              <widget class="QTabWidget" name="fanControlTabWidget">
               <property name="enabled">
@@ -974,7 +984,7 @@
                    </sizepolicy>
                   </property>
                   <property name="text">
-                   <string notr="true">0%</string>
+                   <string notr="true">fan level 0</string>
                   </property>
                   <property name="alignment">
                    <set>Qt::AlignmentFlag::AlignCenter</set>
@@ -1074,7 +1084,7 @@
                    </sizepolicy>
                   </property>
                   <property name="text">
-                   <string notr="true">0%</string>
+                   <string notr="true">fan level 0</string>
                   </property>
                   <property name="alignment">
                    <set>Qt::AlignmentFlag::AlignCenter</set>
@@ -1090,7 +1100,7 @@
                    </sizepolicy>
                   </property>
                   <property name="text">
-                   <string notr="true">0%</string>
+                   <string notr="true">fan level 0</string>
                   </property>
                   <property name="alignment">
                    <set>Qt::AlignmentFlag::AlignCenter</set>
@@ -1106,7 +1116,7 @@
                    </sizepolicy>
                   </property>
                   <property name="text">
-                   <string notr="true">0%</string>
+                   <string notr="true">fan level 0</string>
                   </property>
                   <property name="alignment">
                    <set>Qt::AlignmentFlag::AlignCenter</set>
@@ -1150,7 +1160,7 @@
                    </sizepolicy>
                   </property>
                   <property name="text">
-                   <string notr="true">0%</string>
+                   <string notr="true">fan level 0</string>
                   </property>
                   <property name="alignment">
                    <set>Qt::AlignmentFlag::AlignCenter</set>
@@ -1166,7 +1176,7 @@
                    </sizepolicy>
                   </property>
                   <property name="text">
-                   <string notr="true">0%</string>
+                   <string notr="true">fan level 0</string>
                   </property>
                   <property name="alignment">
                    <set>Qt::AlignmentFlag::AlignCenter</set>
@@ -1210,7 +1220,7 @@
                    </sizepolicy>
                   </property>
                   <property name="text">
-                   <string notr="true">0%</string>
+                   <string notr="true">fan level 0</string>
                   </property>
                   <property name="alignment">
                    <set>Qt::AlignmentFlag::AlignCenter</set>
@@ -1349,7 +1359,7 @@
                    </sizepolicy>
                   </property>
                   <property name="text">
-                   <string notr="true">0%</string>
+                   <string notr="true">fan level 0</string>
                   </property>
                   <property name="alignment">
                    <set>Qt::AlignmentFlag::AlignCenter</set>
@@ -1365,7 +1375,7 @@
                    </sizepolicy>
                   </property>
                   <property name="text">
-                   <string notr="true">0%</string>
+                   <string notr="true">fan level 0</string>
                   </property>
                   <property name="alignment">
                    <set>Qt::AlignmentFlag::AlignCenter</set>
@@ -1447,7 +1457,7 @@
                    </sizepolicy>
                   </property>
                   <property name="text">
-                   <string notr="true">0%</string>
+                   <string notr="true">fan level 0</string>
                   </property>
                   <property name="alignment">
                    <set>Qt::AlignmentFlag::AlignCenter</set>
@@ -1485,7 +1495,7 @@
                    </sizepolicy>
                   </property>
                   <property name="text">
-                   <string notr="true">0%</string>
+                   <string notr="true">fan level 0</string>
                   </property>
                   <property name="alignment">
                    <set>Qt::AlignmentFlag::AlignCenter</set>
@@ -1545,7 +1555,7 @@
                    </sizepolicy>
                   </property>
                   <property name="text">
-                   <string notr="true">0%</string>
+                   <string notr="true">fan level 0</string>
                   </property>
                   <property name="alignment">
                    <set>Qt::AlignmentFlag::AlignCenter</set>
@@ -1561,7 +1571,7 @@
                    </sizepolicy>
                   </property>
                   <property name="text">
-                   <string notr="true">0%</string>
+                   <string notr="true">fan level 0</string>
                   </property>
                   <property name="alignment">
                    <set>Qt::AlignmentFlag::AlignCenter</set>
@@ -1599,7 +1609,7 @@
                    </sizepolicy>
                   </property>
                   <property name="text">
-                   <string notr="true">0%</string>
+                   <string notr="true">fan level 0</string>
                   </property>
                   <property name="alignment">
                    <set>Qt::AlignmentFlag::AlignCenter</set>
@@ -2084,13 +2094,6 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
-           <widget class="QPushButton" name="WriteValueButton">
-            <property name="text">
-             <string notr="true">Write Value</string>
-            </property>
-           </widget>
-          </item>
           <item row="1" column="0">
            <widget class="QLineEdit" name="addressEdit"/>
           </item>
@@ -2164,7 +2167,6 @@
   <tabstop>ValueSpinBox</tabstop>
   <tabstop>addressEdit</tabstop>
   <tabstop>ReadValueButton</tabstop>
-  <tabstop>WriteValueButton</tabstop>
   <tabstop>balancedBatteryRadioButton</tabstop>
   <tabstop>customBatteryApplyButton</tabstop>
  </tabstops>

--- a/src/msi-ec_helper.cpp
+++ b/src/msi-ec_helper.cpp
@@ -18,6 +18,7 @@
 
 #include "msi-ec_helper.h"
 #include "helper/service.h"
+#include "helper/authorization.h"
 #include "mainwindow.h"
 
 #include <QDBusReply>
@@ -27,7 +28,12 @@ MsiEcHelper::MsiEcHelper() {
         fprintf(stderr, "Cannot connect to the D-Bus system bus");
         return;
     }
-    iface = new QDBusInterface(SERVICE_NAME, "/msi_ec", INTERFACE_NAME_MSI_EC, QDBusConnection::systemBus());
+    iface = new QDBusInterface(SERVICE_NAME, "/msi_ec", INTERFACE_NAME_MSI_EC,
+                               QDBusConnection::systemBus(), this);
+    iface->setTimeout(FAN_DBUS_TIMEOUT_MS);
+    // Authentication dialogs are owned by the client-side pkcheck preflight,
+    // never by a privileged helper D-Bus call.
+    iface->setInteractiveAuthorizationAllowed(false);
 }
 
 bool MsiEcHelper::isMsiEcModuleLoaded() {
@@ -45,7 +51,7 @@ bool MsiEcHelper::getWebcam() const {
 }
 
 void MsiEcHelper::setWebcam(bool enabled) const {
-    setValue<bool>("setWebcam", enabled);
+    (void)setValue<bool>("setWebcam", enabled);
 }
 
 //////////////// webcam_block ////////////////
@@ -59,7 +65,7 @@ bool MsiEcHelper::getWebcamBlock() const {
 }
 
 void MsiEcHelper::setWebcamBlock(bool enabled) const {
-    setValue<bool>("setWebcamBlock", enabled);
+    (void)setValue<bool>("setWebcamBlock", enabled);
 }
 
 //////////////// fn_win_swap ////////////////
@@ -72,8 +78,13 @@ bool MsiEcHelper::getFnWinSwap() const {
     return getValue<bool>("getFnWinSwap", false);
 }
 
-void MsiEcHelper::setFnWinSwap(bool swap) const {
-    setValue<bool>("setFnWinSwap", swap);
+bool MsiEcHelper::setFnWinSwap(bool swap) const {
+    if (!iface || !preauthorizeHardwareMutation())
+        return false;
+    if (QDBusReply<bool> reply = iface->call("setFnWinSwap", swap); reply.isValid())
+        return reply.value();
+    printError(iface->lastError());
+    return false;
 }
 
 //////////////// cooler_boost ////////////////
@@ -87,7 +98,7 @@ bool MsiEcHelper::getCoolerBoost() const {
 }
 
 void MsiEcHelper::setCoolerBoost(bool enable) const {
-    setValue<bool>("setCoolerBoost", enable);
+    (void)setValue<bool>("setCoolerBoost", enable);
 }
 
 //////////////// shift_mode ////////////////
@@ -125,7 +136,7 @@ shift_mode MsiEcHelper::getShiftMode() const {
         return shift_mode::unknown_mode;
 }
 
-void MsiEcHelper::setShiftMode(shift_mode mode) const {
+bool MsiEcHelper::setShiftMode(shift_mode mode) const {
     QString modeStr;
     switch(mode) {
         case shift_mode::eco_mode:
@@ -141,9 +152,14 @@ void MsiEcHelper::setShiftMode(shift_mode mode) const {
             modeStr = "turbo";
             break;
         case shift_mode::unknown_mode:
-            return;
+            return false;
         }
-    setValue<QString>("setShiftMode", modeStr);
+    if (!iface || !preauthorizeHardwareMutation())
+        return false;
+    if (QDBusReply<bool> reply = iface->call("setShiftMode", modeStr); reply.isValid())
+        return reply.value();
+    printError(iface->lastError());
+    return false;
 }
 
 //////////////// super_battery ////////////////
@@ -156,8 +172,13 @@ bool MsiEcHelper::getSuperBattery() const {
     return getValue<bool>("getSuperBattery", false);
 }
 
-void MsiEcHelper::setSuperBattery(bool enable) const {
-    setValue<bool>("setSuperBattery", enable);
+bool MsiEcHelper::setSuperBattery(bool enable) const {
+    if (!iface || !preauthorizeHardwareMutation())
+        return false;
+    if (QDBusReply<bool> reply = iface->call("setSuperBattery", enable); reply.isValid())
+        return reply.value();
+    printError(iface->lastError());
+    return false;
 }
 
 //////////////// fan_mode ////////////////
@@ -196,7 +217,7 @@ fan_mode MsiEcHelper::getFanMode() const {
         return fan_mode::unknown_fan_mode;
 }
 
-void MsiEcHelper::setFanMode(fan_mode mode) const {
+bool MsiEcHelper::setFanMode(fan_mode mode) const {
     QString modeStr;
     switch (mode) {
         case fan_mode::auto_fan_mode:
@@ -212,9 +233,61 @@ void MsiEcHelper::setFanMode(fan_mode mode) const {
             modeStr = "advanced";
             break;
         default:
-            return;
+            return false;
     }
-    setValue<QString>("setFanMode", modeStr);
+    if (!iface || !preauthorizeHardwareMutation())
+        return false;
+    if (QDBusReply<bool> reply = iface->call("setFanMode", modeStr); reply.isValid())
+        return reply.value();
+    printError(iface->lastError());
+    return false;
+}
+
+FanCurveCapability MsiEcHelper::getFanCurveCapability() const {
+    if (!iface)
+        return {};
+    if (QDBusReply<QVariantMap> reply = iface->call("getFanCurveCapability"); reply.isValid())
+        return fanCurveCapabilityFromMap(reply.value());
+    printError(iface->lastError());
+    return {};
+}
+
+std::optional<FanCurveProfile> MsiEcHelper::getFanCurveProfile() const {
+    if (!iface)
+        return std::nullopt;
+    if (QDBusReply<QVariantMap> reply = iface->call("getFanCurveProfile"); reply.isValid()) {
+        const QVariantMap map = reply.value();
+        if (!map.value(QStringLiteral("readable"), map.value(QStringLiteral("valid"))).toBool())
+            return std::nullopt;
+        FanCurveProfile profile;
+        if (fanCurveProfileFromMap(map, &profile))
+            return profile;
+        return std::nullopt;
+    }
+    printError(iface->lastError());
+    return std::nullopt;
+}
+
+FanCurveResult MsiEcHelper::applyFanCurveTransaction(const FanCurveProfile &profile) const {
+    FanCurveResult result;
+    if (!iface || !preauthorizeHardwareMutation()) {
+        result.error = QStringLiteral("hardware authorization unavailable");
+        switch (getFanMode()) {
+        case fan_mode::auto_fan_mode: result.effectiveMode = QStringLiteral("auto"); break;
+        case fan_mode::silent_fan_mode: result.effectiveMode = QStringLiteral("silent"); break;
+        case fan_mode::basic_fan_mode: result.effectiveMode = QStringLiteral("basic"); break;
+        case fan_mode::advanced_fan_mode: result.effectiveMode = QStringLiteral("advanced"); break;
+        default: result.effectiveMode = QStringLiteral("unknown"); break;
+        }
+        result.rollbackStatus = QStringLiteral("not-attempted");
+        return result;
+    }
+    if (QDBusReply<QVariantMap> reply = iface->call("applyFanCurveTransaction", fanCurveProfileToMap(profile)); reply.isValid())
+        return fanCurveResultFromMap(reply.value());
+    printError(iface->lastError());
+    result.error = QStringLiteral("fan transaction D-Bus call failed");
+    result.rollbackStatus = QStringLiteral("not-attempted");
+    return result;
 }
 
 //////////////// fw_version ////////////////
@@ -240,7 +313,7 @@ int MsiEcHelper::getCPURealtimeTemperature() const {
     return getValue<int>("getCPURealtimeTemperature", -1);
 }
 
-// cpu/realtime_fan_speed 0-100 (percent)
+// cpu/realtime_fan_speed: driver-reported fan level (not RPM)
 bool MsiEcHelper::hasCPURealtimeFanSpeed() const {
     return getValue<bool>("hasCPURealtimeFanSpeed", false);
 }
@@ -259,7 +332,7 @@ int MsiEcHelper::getCPUBasicFanSpeed() const {
 }
 
 void MsiEcHelper::setCPUBasicFanSpeed(int value) const {
-    setValue<int>("setCPUBasicFanSpeed", value);
+    (void)setValue<int>("setCPUBasicFanSpeed", value);
 }
 
 //////////////// GPU ////////////////
@@ -273,7 +346,7 @@ std::optional<int> MsiEcHelper::getGPURealtimeTemperature() const {
     return getOptionalValue<int>("getGPURealtimeTemperature");
 }
 
-// gpu/realtime_fan_speed 0-100 (percent)
+// gpu/realtime_fan_speed: driver-reported fan level (not RPM)
 bool MsiEcHelper::hasGPURealtimeFanSpeed() const {
     return getValue<bool>("hasGPURealtimeFanSpeed", false);
 }
@@ -294,7 +367,7 @@ int MsiEcHelper::getBatteryStartThreshold() const {
 }
 
 void MsiEcHelper::setBatteryStartThreshold(int value) const {
-    return setValue<int>("setBatteryStartThreshold", value);
+    (void)setValue<int>("setBatteryStartThreshold", value);
 }
 
 // BAT1/charge_control_end_threshold 0-100 (percent)
@@ -307,7 +380,7 @@ int MsiEcHelper::getBatteryEndThreshold() const {
 }
 
 void MsiEcHelper::setBatteryEndThreshold(int value) const {
-    return setValue<int>("setBatteryEndThreshold", value);
+    (void)setValue<int>("setBatteryEndThreshold", value);
 }
 
 // BAT1/capacity 0-100 (percent)
@@ -340,7 +413,7 @@ int MsiEcHelper::getKeyboardBacklightBrightness() const {
 }
 
 void MsiEcHelper::setKeyboardBacklightBrightness(int value) const {
-    return setValue<int>("setKeyboardBacklightBrightness", value);
+    (void)setValue<int>("setKeyboardBacklightBrightness", value);
 }
 
 ////////////////////////////////
@@ -352,6 +425,8 @@ void MsiEcHelper::printError(QDBusError const &error) const {
 
 template <typename T>
 inline std::optional<T> MsiEcHelper::getOptionalValue(QString method) const {
+    if (!iface)
+        return std::nullopt;
     if (QDBusReply<T> reply = iface->call(method); reply.isValid())
         return reply.value();
     printError(iface->lastError());
@@ -364,7 +439,10 @@ inline T MsiEcHelper::getValue(QString method, T defaultValue) const {
 }
 
 template <typename T>
-void MsiEcHelper::setValue(QString method, T value) const {
+bool MsiEcHelper::setValue(QString method, T value) const {
+    if (!iface || !preauthorizeHardwareMutation())
+        return false;
     iface->call(method, value);
     printError(iface->lastError());
+    return !iface->lastError().isValid();
 }

--- a/src/msi-ec_helper.h
+++ b/src/msi-ec_helper.h
@@ -20,6 +20,7 @@
 #define MSI_EC_HELPER_H
 
 #include "operate.h"
+#include "fan_curve.h"
 #include <QtCore/QObject>
 #include <QtDBus/QDBusInterface>
 
@@ -43,7 +44,7 @@ public:
     // fn_win_swap swap/no swap
     [[nodiscard]] bool hasFnWinSwap() const;
     [[nodiscard]] bool getFnWinSwap() const;
-    Q_NOREPLY void setFnWinSwap(bool swap) const;
+    [[nodiscard]] bool setFnWinSwap(bool swap) const;
 
     // cooler_boost
     [[nodiscard]] bool hasCoolerBoost() const;
@@ -54,18 +55,23 @@ public:
     [[nodiscard]] bool hasShiftMode() const;
     [[nodiscard]] QList<shift_mode> getAvailableShiftModes() const;
     [[nodiscard]] shift_mode getShiftMode() const;
-    Q_NOREPLY void setShiftMode(shift_mode mode) const;
+    [[nodiscard]] bool setShiftMode(shift_mode mode) const;
 
     // super_battery
     [[nodiscard]] bool hasSuperBattery() const;
     [[nodiscard]] bool getSuperBattery() const;
-    Q_NOREPLY void setSuperBattery(bool enable) const;
+    [[nodiscard]] bool setSuperBattery(bool enable) const;
 
     // fan_mode & available_fan_modes
     [[nodiscard]] bool hasFanMode() const;
     [[nodiscard]] QList<fan_mode> getAvailableFanModes() const;
     [[nodiscard]] fan_mode getFanMode() const;
-    Q_NOREPLY void setFanMode(fan_mode mode) const;
+    [[nodiscard]] bool setFanMode(fan_mode mode) const;
+
+    // Complete fan-curve ABI. Advanced mode alone is not sufficient.
+    [[nodiscard]] FanCurveCapability getFanCurveCapability() const;
+    [[nodiscard]] std::optional<FanCurveProfile> getFanCurveProfile() const;
+    [[nodiscard]] FanCurveResult applyFanCurveTransaction(const FanCurveProfile &profile) const;
 
     // fw_version
     [[nodiscard]] QString getFWVersion() const;
@@ -75,7 +81,7 @@ public:
     // cpu/realtime_temperature 0-100 (celsius scale)
     [[nodiscard]] bool hasCPURealtimeTemperature() const;
     [[nodiscard]] int getCPURealtimeTemperature() const;
-    // cpu/realtime_fan_speed 0-100 (percent)
+    // cpu/realtime_fan_speed: driver-reported fan level (not RPM)
     [[nodiscard]] bool hasCPURealtimeFanSpeed() const;
     [[nodiscard]] int getCPURealtimeFanSpeed() const;
     // cpu/basic_fan_speed 0-100 (percent)
@@ -86,7 +92,7 @@ public:
     // gpu/realtime_temperature 0-100 (celsius scale)
     [[nodiscard]] bool hasGPURealtimeTemperature() const;
     [[nodiscard]] std::optional<int> getGPURealtimeTemperature() const;
-    // gpu/realtime_fan_speed 0-100 (percent)
+    // gpu/realtime_fan_speed: driver-reported fan level (not RPM)
     [[nodiscard]] bool hasGPURealtimeFanSpeed() const;
     [[nodiscard]] std::optional<int> getGPURealtimeFanSpeed() const;
 
@@ -114,7 +120,7 @@ public:
     Q_NOREPLY void setKeyboardBacklightBrightness(int value) const;
 
 private:
-    QDBusInterface *iface;
+    QDBusInterface *iface = nullptr;
     void printError(QDBusError const &error) const;
 
     template <typename T>
@@ -122,7 +128,7 @@ private:
     template <typename T>
     [[nodiscard]] T getValue(QString method, T defaultValue) const;
     template <typename T>
-    Q_NOREPLY void setValue(QString method, T value) const;
+    [[nodiscard]] bool setValue(QString method, T value) const;
 };
 
 #endif // MSI_EC_HELPER_H

--- a/src/operate.cpp
+++ b/src/operate.cpp
@@ -72,12 +72,21 @@ const int fanModeBasic = 0x4D;
 const int fanModeAdvanced = 0x8D;
 
 const QString settingsGroup = "Settings/";
+const QString fanCurveSettingsGroup = "Settings/FanCurve/";
+
+namespace {
+QString fanModeString(fan_mode mode) {
+    switch (mode) {
+    case fan_mode::auto_fan_mode: return QStringLiteral("auto");
+    case fan_mode::silent_fan_mode: return QStringLiteral("silent");
+    case fan_mode::basic_fan_mode: return QStringLiteral("basic");
+    case fan_mode::advanced_fan_mode: return QStringLiteral("advanced");
+    default: return QStringLiteral("unknown");
+    }
+}
+}
 
 Operate::Operate() = default;
-
-void Operate::closeHelperApp() const {
-    helper.quit();
-}
 
 bool Operate::isEcSysModuleLoaded() const {
     return helper.isEcSysModuleLoaded();
@@ -92,11 +101,15 @@ bool Operate::loadEcSysModule() const {
 }
 
 bool Operate::updateEcData() const {
-    return helper.updateData();
+    if (helper.isEcSysModuleLoaded())
+        return helper.updateData() || msiEcHelper.isMsiEcModuleLoaded();
+    // Typed msi_ec controls remain fully usable without raw EC diagnostics.
+    return msiEcHelper.isMsiEcModuleLoaded();
 }
 
 void Operate::updateEcDataAsync() const {
-    helper.updateDataAsync();
+    if (helper.isEcSysModuleLoaded())
+        helper.updateDataAsync();
 }
 
 bool Operate::doProbe() const {
@@ -169,18 +182,23 @@ std::optional<int> Operate::getGpuTemp() const {
         return helper.getValue(gpuTempAddress);
 }
 
-int Operate::getFan1Speed() const {
-    // Read 2 bytes (big-endian)
-    int value0 = helper.getValue(fan1Address);
-    int value1 = helper.getValue(fan1Address - 1);
-    int value = (value1 << 8) | value0;
-    if (value > 0)
-        return 480000 / value;
-    return value;
+std::optional<int> Operate::getFan1Speed() const {
+    // msi-ec realtime_fan_speed is a level-like byte, not RPM. The RPM UI is
+    // populated only by the optional read-only EC tachometer diagnostics.
+    if (!helper.isEcSysModuleLoaded())
+        return std::nullopt;
+    const auto value0 = helper.getOptionalValue(fan1Address);
+    const auto value1 = helper.getOptionalValue(fan1Address - 1);
+    if (!value0.has_value() || !value1.has_value())
+        return std::nullopt;
+    const int value = (value1.value() << 8) | value0.value();
+    return value > 0 ? std::optional<int>(480000 / value) : std::optional<int>(value);
 }
 
 std::optional<int> Operate::getFan2Speed() const {
-    if (msiEcHelper.isMsiEcModuleLoaded() && !msiEcHelper.hasGPURealtimeFanSpeed())
+    // msi-ec realtime_fan_speed is not RPM; use only optional raw EC
+    // tachometer diagnostics when ec_sys/acpi_ec is actually available.
+    if (!helper.isEcSysModuleLoaded())
         return std::nullopt;
     // Read 2 bytes (big-endian)
     auto value0 = helper.getOptionalValue(fan2Address);
@@ -194,35 +212,27 @@ std::optional<int> Operate::getFan2Speed() const {
 }
 
 QVector<int> Operate::getFan1SpeedSettings() const {
-    QVector<int> a;
-    for (int i = 0; i < fanSpeedSettingsCount; i++) {
-        a.push_back(helper.getValue(fan1SpeedSettingStartAddress + i));
-    }
-    return a;
+    if (const auto profile = getFanCurveProfile(); profile.has_value())
+        return profile->cpuLevels;
+    return {};
 }
 
 QVector<int> Operate::getFan2SpeedSettings() const {
-    QVector<int> a;
-    for (int i = 0; i < fanSpeedSettingsCount; i++) {
-        a.push_back(helper.getValue(fan2SpeedSettingStartAddress + i));
-    }
-    return a;
+    if (const auto profile = getFanCurveProfile(); profile.has_value())
+        return profile->gpuLevels;
+    return {};
 }
 
 QVector<int> Operate::getFan1TempSettings() const {
-    QVector<int> a;
-    for (int i = 0; i < fanTempSettingsCount; i++) {
-        a.push_back(helper.getValue(fan1TempSettingStartAddress + i));
-    }
-    return a;
+    if (const auto profile = getFanCurveProfile(); profile.has_value())
+        return profile->cpuThresholds;
+    return {};
 }
 
 QVector<int> Operate::getFan2TempSettings() const {
-    QVector<int> a;
-    for (int i = 0; i < fanTempSettingsCount; i++) {
-        a.push_back(helper.getValue(fan2TempSettingStartAddress + i));
-    }
-    return a;
+    if (const auto profile = getFanCurveProfile(); profile.has_value())
+        return profile->gpuThresholds;
+    return {};
 }
 
 int Operate::getKeyboardBacklightMode() const {
@@ -318,47 +328,91 @@ fan_mode Operate::getFanMode() const {
     }
 }
 
+FanCurveCapability Operate::getFanCurveCapability() const {
+    if (!msiEcHelper.isMsiEcModuleLoaded())
+        return {};
+    return msiEcHelper.getFanCurveCapability();
+}
+
+std::optional<FanCurveProfile> Operate::getFanCurveProfile() const {
+    if (!getFanCurveCapability().complete())
+        return std::nullopt;
+    return msiEcHelper.getFanCurveProfile();
+}
+
+FanCurveResult Operate::applyFanCurve(const FanCurveProfile &profile) const {
+    FanCurveResult result;
+    const FanCurveCapability capability = getFanCurveCapability();
+    if (const QString error = validateFanCurve(capability, profile); !error.isEmpty()) {
+        result.error = error;
+        result.effectiveMode = fanModeString(getFanMode());
+        result.rollbackStatus = QStringLiteral("not-attempted");
+        return result;
+    }
+    result = msiEcHelper.applyFanCurveTransaction(profile);
+    if (result.success) {
+        Settings::setValue(fanCurveSettingsGroup + QStringLiteral("Verified"), true);
+        Settings::setValue(fanCurveSettingsGroup + QStringLiteral("FirmwareVersion"),
+                           QString::fromStdString(getEcVersion()));
+        Settings::setValue(fanCurveSettingsGroup + QStringLiteral("FirmwareDate"),
+                           QString::fromStdString(getEcBuild()));
+        Settings::setValue(fanCurveSettingsGroup + QStringLiteral("CpuThresholds"), profile.cpuThresholds);
+        Settings::setValue(fanCurveSettingsGroup + QStringLiteral("CpuLevels"), profile.cpuLevels);
+        Settings::setValue(fanCurveSettingsGroup + QStringLiteral("GpuThresholds"), profile.gpuThresholds);
+        Settings::setValue(fanCurveSettingsGroup + QStringLiteral("GpuLevels"), profile.gpuLevels);
+        Settings::setValue(fanCurveSettingsGroup + QStringLiteral("Advanced"), true);
+    }
+    return result;
+}
+
+QString Operate::savedFanCurveKey(const QString &suffix) const {
+    return fanCurveSettingsGroup + suffix;
+}
+
+bool Operate::readVerifiedSavedFanCurve(FanCurveProfile *profile) const {
+    Settings settings;
+    if (!profile || !settings.getValue(savedFanCurveKey(QStringLiteral("Verified"))).toBool())
+        return false;
+    const QString savedVersion = settings.getValue(savedFanCurveKey(QStringLiteral("FirmwareVersion"))).toString();
+    const QString savedDate = settings.getValue(savedFanCurveKey(QStringLiteral("FirmwareDate"))).toString();
+    if (!fanCurveFirmwareMatches(savedVersion, savedDate,
+                                 QString::fromStdString(getEcVersion()),
+                                 QString::fromStdString(getEcBuild())))
+        return false;
+    auto readVector = [&](const QString &key, QVector<int> *values) {
+        bool ok = false;
+        *values = settings.getValueVector(key, &ok);
+        return ok;
+    };
+    return readVector(savedFanCurveKey(QStringLiteral("CpuThresholds")), &profile->cpuThresholds) &&
+           readVector(savedFanCurveKey(QStringLiteral("CpuLevels")), &profile->cpuLevels) &&
+           readVector(savedFanCurveKey(QStringLiteral("GpuThresholds")), &profile->gpuThresholds) &&
+           readVector(savedFanCurveKey(QStringLiteral("GpuLevels")), &profile->gpuLevels) &&
+           validateFanCurve(getFanCurveCapability(), *profile).isEmpty();
+}
+
+bool Operate::hasVerifiedSavedFanCurve() const {
+    FanCurveProfile profile;
+    return readVerifiedSavedFanCurve(&profile);
+}
+
 void Operate::setBatteryThreshold(int value) const {
     if (msiEcHelper.hasBatteryEndThreshold())
         return msiEcHelper.setBatteryEndThreshold(value);
-    if (value != getBatteryThreshold())
-        helper.putValue(batteryThresholdAddress, value + 128);
 }
 
 void Operate::setKeyboardBacklightMode(int value) const {
-    int resValue = keyboardBacklightAlwaysOn;
-    if (value == 1)
-        resValue = keyboardBacklightAutoTurnOff;
-    helper.putValue(keyboardBacklightModeAddress, resValue);
+    Q_UNUSED(value); // raw EC writes are intentionally unavailable
 }
 
 void Operate::setKeyboardBrightness(int value) const {
     if (msiEcHelper.hasKeyboardBacklightBrightness())
         return msiEcHelper.setKeyboardBacklightBrightness(value);
-    int resValue;
-    switch (value) {
-        case 0:
-            resValue = keyboardBacklight0ff;
-            break;
-        case 1:
-            resValue = keyboardBacklightLow;
-            break;
-        case 2:
-            resValue = keyboardBacklightMid;
-            break;
-        case 3:
-            resValue = keyboardBacklightHigh;
-            break;
-        default:
-            resValue = keyboardBacklight0ff;
-    }
-    helper.putValue(keyboardBacklightAddress, resValue);
+    Q_UNUSED(value); // unsupported without a typed msi-ec sysfs node
 }
 
 void Operate::setUsbPowerShareState(bool enabled) const {
-    int value = enabled ? usbPowerShareOn : usbPowerShareOff;
-    helper.putValue(usbPowerShareAddress, value);
-    Settings::setValue(settingsGroup + "UsbPowerShare", enabled);
+    Q_UNUSED(enabled); // arbitrary raw EC writes are unavailable
 }
 
 void Operate::setWebCamState(bool enabled) const {
@@ -366,27 +420,22 @@ void Operate::setWebCamState(bool enabled) const {
         return msiEcHelper.setWebcam(enabled);
 }
 
-void Operate::setFnSuperSwapState(bool enabled) const {
-    Settings::setValue(settingsGroup + "FnSuperSwap", enabled);
-    if (msiEcHelper.hasFnWinSwap())
-        return msiEcHelper.setFnWinSwap(enabled);
-    if (getFnSuperSwapState() == enabled)
-        return;
-    int value = helper.getValue(fnSuperSwapAddress) + (enabled ? 16 : -16);
-    helper.putValue(fnSuperSwapAddress, value);
+bool Operate::setFnSuperSwapState(bool enabled) const {
+    if (!msiEcHelper.hasFnWinSwap())
+        return false;
+    const bool verified = msiEcHelper.setFnWinSwap(enabled);
+    if (verified)
+        Settings::setValue(settingsGroup + QStringLiteral("FnSuperSwap"), enabled);
+    return verified;
 }
 
 void Operate::setCoolerBoostState(bool enabled) const {
     if (msiEcHelper.hasCoolerBoost())
         return msiEcHelper.setCoolerBoost(enabled);
-    int value = helper.getValue(coolerBoostAddress);
-    if (enabled && (value < 128))
-        helper.putValue(coolerBoostAddress, value + 128);
-    if (!enabled && (value > 127))
-        helper.putValue(coolerBoostAddress, value - 128);
+    Q_UNUSED(enabled); // unsupported without a typed msi-ec sysfs node
 }
 
-void Operate::setUserMode(user_mode userMode) const {
+bool Operate::setUserMode(user_mode userMode) const {
     shift_mode shiftMode = shift_mode::comfort_mode;
     fan_mode fanMode = fan_mode::auto_fan_mode;
     bool superBattery = false;
@@ -410,72 +459,79 @@ void Operate::setUserMode(user_mode userMode) const {
             userModeStr = "super_battery_mode";
             break;
         default:
-            return;
+            return false;
     }
 
-    if (msiEcHelper.hasShiftMode()) {
-        msiEcHelper.setShiftMode(shiftMode);
-    }
-    
-    if (msiEcHelper.hasFanMode()) {
-        msiEcHelper.setFanMode(fanMode);
-    }
+    bool verified = true;
+    if (msiEcHelper.hasShiftMode())
+        verified = msiEcHelper.setShiftMode(shiftMode) && verified;
+    if (msiEcHelper.hasFanMode())
+        verified = msiEcHelper.setFanMode(fanMode) && verified;
+    if (msiEcHelper.hasSuperBattery())
+        verified = msiEcHelper.setSuperBattery(superBattery) && verified;
 
-    if (msiEcHelper.hasSuperBattery()) {
-        msiEcHelper.setSuperBattery(superBattery);
-    }
+    Settings::setValue(settingsGroup + QStringLiteral("FanModeSetError"), !verified);
+    if (!verified)
+        return false;
 
-    Settings::setValue(settingsGroup + "UserMode", userModeStr);
+    Settings::setValue(settingsGroup + QStringLiteral("UserMode"), userModeStr);
+    // Silent and Super Battery must not inherit a stale Advanced preference.
+    if (userMode == user_mode::silent_mode || userMode == user_mode::super_battery_mode)
+        Settings::setValue(fanCurveSettingsGroup + QStringLiteral("Advanced"), false);
+    return true;
+}
+
+std::optional<FanCurveResult> Operate::reconcileFanCurvePreference() const {
+    Settings settings;
+    if (!settings.getValue(savedFanCurveKey(QStringLiteral("Advanced"))).toBool())
+        return std::nullopt;
+    FanCurveProfile profile;
+    if (!readVerifiedSavedFanCurve(&profile)) {
+        FanCurveResult result;
+        result.error = QStringLiteral("saved fan curve is unavailable or firmware-bound validation failed");
+        result.effectiveMode = QStringLiteral("unknown");
+        result.rollbackStatus = QStringLiteral("not-attempted");
+        return result;
+    }
+    return applyFanCurve(profile);
 }
 
 void Operate::setFan1SpeedSettings(QVector<int> value) const {
-    if (value.size() != fanSpeedSettingsCount)
-        return;
-    for (int i = 0; i < value.size(); i++) {
-        helper.putValue(fan1SpeedSettingStartAddress + i, value[i]);
-    }
-    Settings::setValue(settingsGroup + QString("fan1SpeedSettings"), value);
+    Q_UNUSED(value); // use applyFanCurve for one transactional operation
 }
 
 void Operate::setFan2SpeedSettings(QVector<int> value) const {
-    if (value.size() != fanSpeedSettingsCount)
-        return;
-    for (int i = 0; i < value.size(); i++) {
-        helper.putValue(fan2SpeedSettingStartAddress + i, value[i]);
-    }
-    Settings::setValue(settingsGroup + QString("fan2SpeedSettings"), value);
+    Q_UNUSED(value);
 }
 
 void Operate::setFan1TempSettings(QVector<int> value) const {
-    if (value.size() != fanTempSettingsCount)
-        return;
-    for (int i = 0; i < value.size(); i++) {
-        helper.putValue(fan1TempSettingStartAddress + i, value[i]);
-    }
-    Settings::setValue(settingsGroup + QString("fan1TempSettings"), value);
+    Q_UNUSED(value);
 }
 
 void Operate::setFan2TempSettings(QVector<int> value) const {
-    if (value.size() != fanTempSettingsCount)
-        return;
-    for (int i = 0; i < value.size(); i++) {
-        helper.putValue(fan2TempSettingStartAddress + i, value[i]);
-    }
-    Settings::setValue(settingsGroup + QString("fan2TempSettings"), value);
+    Q_UNUSED(value);
 }
 
 void Operate::setFanMode(int value) const {
-    if (helper.getValue(fanModeAddress) == fanModeAdvanced)
-        return;
-    helper.putValue(fanModeAddress, value);
+    Q_UNUSED(value); // raw EC fan mode writes are intentionally unavailable
 }
 
-void Operate::setFanModeAdvanced(bool enabled) const {
-    if (enabled)
-        helper.putValue(fanModeAddress, fanModeAdvanced);
-    else
-        helper.putValue(fanModeAddress, fanModeAuto);
-    Settings::setValue(settingsGroup + "fanModeAdvanced", enabled);
+bool Operate::setFanModeAdvanced(bool enabled) const {
+    if (!msiEcHelper.hasFanMode())
+        return false;
+    if (!enabled) {
+        if (!msiEcHelper.setFanMode(fan_mode::auto_fan_mode) ||
+            getFanMode() != fan_mode::auto_fan_mode)
+            return false;
+        Settings::setValue(fanCurveSettingsGroup + QStringLiteral("Advanced"), false);
+        return true;
+    }
+    FanCurveProfile profile;
+    if (const auto current = getFanCurveProfile(); current.has_value())
+        profile = *current;
+    else if (!readVerifiedSavedFanCurve(&profile))
+        return false;
+    return applyFanCurve(profile).success;
 }
 
 int Operate::getValue(int address) const {
@@ -483,22 +539,12 @@ int Operate::getValue(int address) const {
     return helper.getValue(address);
 }
 
-void Operate::setValue(int address, int value) const {
-    helper.putValue(address, value);
-}
-
 bool Operate::isBatteryThresholdSupport() const {
-    return msiEcHelper.hasBatteryEndThreshold() || batteryThresholdAddress != 0;
+    return msiEcHelper.hasBatteryEndThreshold();
 }
 
 bool Operate::isKeyboardBacklightModeSupport() const {
-    // Backlight mode is not available for all keyboard with backlight
-    
-    // Keep the same behaviour for devices with brightness at 0xD3
-    if (keyboardBacklightAddress == keyboardBacklightAddress_0xD3)
-        return true;
-    
-    // By security, we concider that devices with brightness at 0xF3 don't have backlight mode
+    // The old raw EC fallback is intentionally unavailable.
     return false;
 }
 
@@ -509,52 +555,91 @@ bool Operate::isKeyboardBacklightSupport() const {
 }
 
 bool Operate::isUsbPowerShareSupport() const {
-    return (helper.getValue(usbPowerShareAddress) == usbPowerShareOff ||
-            helper.getValue(usbPowerShareAddress) == usbPowerShareOn);
-}
-
-bool Operate::isWebCamOffSupport() const {
-    if (msiEcHelper.hasWebcamBlock())
-        return true;
+    // No typed msi-ec node exists in this ABI; do not expose a control that
+    // would silently attempt a removed raw EC write.
     return false;
 }
 
-void Operate::loadSettings() const {
-    Settings s;
-
-    if (getUserMode() != user_mode::unknown_mode && s.isValueExist(settingsGroup + "UserMode")) {
-        QString value = s.getValue(settingsGroup + "UserMode").toString();
-        if (value == "balanced_mode")
-            setUserMode(user_mode::balanced_mode);
-        else if (value == "performance_mode")
-            setUserMode(user_mode::performance_mode);
-        else if (value == "silent_mode")
-            setUserMode(user_mode::silent_mode);
-        else if (value == "super_battery_mode")
-            setUserMode(user_mode::super_battery_mode);
-    }
-
-    if (s.isValueExist(settingsGroup + "FnSuperSwap"))
-        setFnSuperSwapState(s.getValue(settingsGroup + "FnSuperSwap").toBool());
-    if (isUsbPowerShareSupport() && s.isValueExist(settingsGroup + "UsbPowerShare"))
-        setUsbPowerShareState(s.getValue(settingsGroup + "UsbPowerShare").toBool());
-
-    if (s.isValueExist(settingsGroup + "fan1SpeedSettings"))
-        setFan1SpeedSettings(s.getValueVector(settingsGroup + "fan1SpeedSettings"));
-    if (s.isValueExist(settingsGroup + "fan2SpeedSettings"))
-        setFan2SpeedSettings(s.getValueVector(settingsGroup + "fan2SpeedSettings"));
-    if (s.isValueExist(settingsGroup + "fan1TempSettings"))
-        setFan1TempSettings(s.getValueVector(settingsGroup + "fan1TempSettings"));
-    if (s.isValueExist(settingsGroup + "fan2TempSettings"))
-        setFan2TempSettings(s.getValueVector(settingsGroup + "fan2TempSettings"));
-    if (s.isValueExist(settingsGroup + "fanModeAdvanced"))
-        setFanModeAdvanced(s.getValue(settingsGroup + "fanModeAdvanced").toBool());
+bool Operate::isWebCamOffSupport() const {
+    // This checkbox controls the typed webcam state node used by the setter.
+    return msiEcHelper.hasWebcam();
 }
 
-void Operate::handleWakeEvent() const {
+bool Operate::isFnSuperSwapSupport() const {
+    return msiEcHelper.hasFnWinSwap();
+}
+
+bool Operate::isCoolerBoostSupport() const {
+    return msiEcHelper.hasCoolerBoost();
+}
+
+namespace {
+FanCurveResult preferenceFailure(const QString &error,
+                                 const QString &effectiveMode = QStringLiteral("unknown")) {
+    FanCurveResult result;
+    result.error = error;
+    result.effectiveMode = effectiveMode;
+    result.rollbackStatus = QStringLiteral("not-attempted");
+    return result;
+}
+}
+
+std::optional<FanCurveResult> Operate::loadSettings() const {
     Settings s;
-    if (s.isValueExist(settingsGroup + "fanModeAdvanced"))
-        setFanModeAdvanced(s.getValue(settingsGroup + "fanModeAdvanced").toBool());
+    std::optional<user_mode> savedMode;
+    const QString savedModeKey = settingsGroup + QStringLiteral("UserMode");
+
+    // Apply a validated saved mode first, even when firmware currently reports
+    // Unknown. A readback-verified setter is the source of truth. An absent
+    // mode does not prevent independent settings from being restored.
+    if (s.isValueExist(savedModeKey)) {
+        savedMode = parseSavedUserMode(s.getValue(savedModeKey).toString());
+        if (!savedMode.has_value())
+            return preferenceFailure(QStringLiteral("saved user mode is invalid"));
+        if (!setUserMode(*savedMode))
+            return preferenceFailure(QStringLiteral("saved user mode could not be verified"));
+    }
+
+    if (s.isValueExist(settingsGroup + QStringLiteral("FnSuperSwap")) &&
+        !setFnSuperSwapState(s.getValue(settingsGroup + QStringLiteral("FnSuperSwap")).toBool()))
+        return preferenceFailure(QStringLiteral("saved Fn/Super swap state could not be verified"));
+    if (isUsbPowerShareSupport() && s.isValueExist(settingsGroup + QStringLiteral("UsbPowerShare")))
+        setUsbPowerShareState(s.getValue(settingsGroup + QStringLiteral("UsbPowerShare")).toBool());
+
+    const bool advancedRequested = s.getValue(savedFanCurveKey(QStringLiteral("Advanced"))).toBool();
+    // Silent/Super Battery clear Advanced in setUserMode. Balanced/Performance
+    // may restore a complete, firmware-bound verified profile.
+    if (!advancedRequested || !savedMode.has_value() || !userModeMayOwnAdvanced(*savedMode))
+        return std::nullopt;
+    return reconcileFanCurvePreference();
+}
+
+std::optional<FanCurveResult> Operate::handleWakeEvent() const {
+    Settings s;
+    const QString savedModeKey = settingsGroup + QStringLiteral("UserMode");
+    if (!s.isValueExist(savedModeKey))
+        return std::nullopt;
+    const auto savedMode = parseSavedUserMode(s.getValue(savedModeKey).toString());
+    if (!savedMode.has_value())
+        return preferenceFailure(QStringLiteral("resume saved user mode is invalid"));
+
+    // The base mode owns resume. Restore and verify it before inspecting or
+    // applying any optional curve so Silent/Super Battery cannot be overridden.
+    if (!setUserMode(*savedMode))
+        return preferenceFailure(QStringLiteral("resume user mode could not be verified"));
+
+    const bool advancedRequested =
+        s.getValue(savedFanCurveKey(QStringLiteral("Advanced"))).toBool();
+    if (!advancedRequested || !userModeMayOwnAdvanced(*savedMode))
+        return std::nullopt;
+
+    FanCurveProfile profile;
+    if (!readVerifiedSavedFanCurve(&profile)) {
+        return preferenceFailure(
+            QStringLiteral("saved fan curve is unavailable or firmware-bound validation failed"),
+            fanModeString(getFanMode()));
+    }
+    return applyFanCurve(profile);
 }
 
 int Operate::detectFan1Address() const {

--- a/src/operate.h
+++ b/src/operate.h
@@ -20,7 +20,10 @@
 #define OPERATE_H
 
 
+#include "fan_curve.h"
+#include "user_mode_policy.h"
 #include <string>
+#include <optional>
 #include <QVector>
 
 enum class charging_state {
@@ -39,14 +42,6 @@ enum class shift_mode {
     unknown_mode
 };
 
-enum class user_mode {
-    performance_mode,
-    balanced_mode,
-    silent_mode,
-    super_battery_mode,
-    unknown_mode
-};
-
 enum class fan_mode {
     auto_fan_mode,
     silent_fan_mode,
@@ -58,7 +53,6 @@ enum class fan_mode {
 class Operate {
 public:
     Operate();
-    void closeHelperApp() const;
     [[nodiscard]] bool isEcSysModuleLoaded() const;
     [[nodiscard]] bool isMsiEcLoaded() const;
     [[nodiscard]] bool loadEcSysModule() const;
@@ -72,12 +66,17 @@ public:
     [[nodiscard]] charging_state getChargingStatus() const;
     [[nodiscard]] int getCpuTemp() const;
     [[nodiscard]] std::optional<int> getGpuTemp() const;
-    [[nodiscard]] int getFan1Speed() const;
+    [[nodiscard]] std::optional<int> getFan1Speed() const;
     [[nodiscard]] std::optional<int> getFan2Speed() const;
     [[nodiscard]] QVector<int> getFan1SpeedSettings() const;
     [[nodiscard]] QVector<int> getFan2SpeedSettings() const;
     [[nodiscard]] QVector<int> getFan1TempSettings() const;
     [[nodiscard]] QVector<int> getFan2TempSettings() const;
+    [[nodiscard]] FanCurveCapability getFanCurveCapability() const;
+    [[nodiscard]] std::optional<FanCurveProfile> getFanCurveProfile() const;
+    [[nodiscard]] FanCurveResult applyFanCurve(const FanCurveProfile &profile) const;
+    [[nodiscard]] bool hasVerifiedSavedFanCurve() const;
+    [[nodiscard]] std::optional<FanCurveResult> reconcileFanCurvePreference() const;
 
     [[nodiscard]] int getKeyboardBacklightMode() const;
     [[nodiscard]] int getKeyboardBrightness() const;
@@ -93,30 +92,33 @@ public:
     void setKeyboardBrightness(int value) const;
     void setUsbPowerShareState(bool enabled) const;
     void setWebCamState(bool enabled) const;
-    void setFnSuperSwapState(bool enabled) const;
+    [[nodiscard]] bool setFnSuperSwapState(bool enabled) const;
     void setCoolerBoostState(bool enabled) const;
-    void setUserMode(user_mode userMode) const;
+    bool setUserMode(user_mode userMode) const;
     void setFan1SpeedSettings(QVector<int> value) const;
     void setFan2SpeedSettings(QVector<int> value) const;
     void setFan1TempSettings(QVector<int> value) const;
     void setFan2TempSettings(QVector<int> value) const;
     void setFanMode(int value) const;
-    void setFanModeAdvanced(bool enabled) const;
+    bool setFanModeAdvanced(bool enabled) const;
 
     [[nodiscard]] int getValue(int address) const;
-    void setValue(int address, int value) const;
 
     [[nodiscard]] bool isBatteryThresholdSupport() const;
     [[nodiscard]] bool isKeyboardBacklightModeSupport() const;
     [[nodiscard]] bool isKeyboardBacklightSupport() const;
     [[nodiscard]] bool isUsbPowerShareSupport() const;
     [[nodiscard]] bool isWebCamOffSupport() const;
+    [[nodiscard]] bool isFnSuperSwapSupport() const;
+    [[nodiscard]] bool isCoolerBoostSupport() const;
 
-    void loadSettings() const;
-    void handleWakeEvent() const;
+    [[nodiscard]] std::optional<FanCurveResult> loadSettings() const;
+    [[nodiscard]] std::optional<FanCurveResult> handleWakeEvent() const;
 
     void putSuperBatteryModeValue(bool enabled) const;
 private:
+    [[nodiscard]] bool readVerifiedSavedFanCurve(FanCurveProfile *profile) const;
+    [[nodiscard]] QString savedFanCurveKey(const QString &suffix) const;
     int detectFan1Address() const;
     int detectBatteryThresholdAddress() const;
     int detectFanModeAddress() const;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -17,7 +17,6 @@
  */
 
 #include <QSettings>
-#include <sstream>
 #include "settings.h"
 
 QSettings settings("MControlCenter");
@@ -26,15 +25,8 @@ QVariant Settings::getValue(const QString &key) {
     return settings.value(key);
 }
 
-QVector<int> Settings::getValueVector(const QString &key) {
-    QVector<int> value;
-    std::stringstream string_stream(settings.value(key).toString().toStdString());
-    while (string_stream.good()) {
-        std::string a;
-        getline(string_stream, a, '|');
-        value.append(std::stoi(a));
-    }
-    return value;
+QVector<int> Settings::getValueVector(const QString &key, bool *ok) {
+    return parseValueVector(settings.value(key).toString(), ok);
 }
 
 void Settings::setValue(const QString &key, const QVariant &value) {

--- a/src/settings.h
+++ b/src/settings.h
@@ -21,11 +21,14 @@
 
 
 #include <QString>
+#include <QVariant>
+#include <QVector>
 
 class Settings {
 public:
     QVariant getValue(const QString &key);
-    QVector<int> getValueVector(const QString &key);
+    QVector<int> getValueVector(const QString &key, bool *ok = nullptr);
+    static QVector<int> parseValueVector(const QString &encoded, bool *ok = nullptr);
     static void setValue(const QString &key, const QVariant &value);
     static void setValue(const QString &key, const QVector<int> &value);
     bool isValueExist(const QString &key);

--- a/src/settings_parse.cpp
+++ b/src/settings_parse.cpp
@@ -1,0 +1,33 @@
+/* Copyright (C) 2022  Dmitry Serov
+ *
+ * This file is part of MControlCenter.
+ *
+ * MControlCenter is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ */
+
+#include "settings.h"
+
+#include <QStringList>
+
+QVector<int> Settings::parseValueVector(const QString &encoded, bool *ok) {
+    QVector<int> value;
+    if (ok)
+        *ok = false;
+    if (encoded.isEmpty())
+        return value;
+    const QStringList entries = encoded.split(QLatin1Char('|'), Qt::KeepEmptyParts);
+    value.reserve(entries.size());
+    for (const QString &entry : entries) {
+        bool converted = false;
+        const int parsed = entry.toInt(&converted);
+        if (!converted)
+            return {};
+        value.append(parsed);
+    }
+    if (ok)
+        *ok = true;
+    return value;
+}

--- a/src/user_mode_policy.cpp
+++ b/src/user_mode_policy.cpp
@@ -1,0 +1,27 @@
+/* Copyright (C) 2022  Dmitry Serov
+ *
+ * This file is part of MControlCenter.
+ *
+ * MControlCenter is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ */
+
+#include "user_mode_policy.h"
+
+std::optional<user_mode> parseSavedUserMode(const QString &value) {
+    if (value == QStringLiteral("balanced_mode"))
+        return user_mode::balanced_mode;
+    if (value == QStringLiteral("performance_mode"))
+        return user_mode::performance_mode;
+    if (value == QStringLiteral("silent_mode"))
+        return user_mode::silent_mode;
+    if (value == QStringLiteral("super_battery_mode"))
+        return user_mode::super_battery_mode;
+    return std::nullopt;
+}
+
+bool userModeMayOwnAdvanced(user_mode mode) {
+    return mode == user_mode::balanced_mode || mode == user_mode::performance_mode;
+}

--- a/src/user_mode_policy.h
+++ b/src/user_mode_policy.h
@@ -1,0 +1,29 @@
+/* Copyright (C) 2022  Dmitry Serov
+ *
+ * This file is part of MControlCenter.
+ *
+ * MControlCenter is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ */
+
+#ifndef MCONTROLCENTER_USER_MODE_POLICY_H
+#define MCONTROLCENTER_USER_MODE_POLICY_H
+
+#include <optional>
+
+#include <QString>
+
+enum class user_mode {
+    performance_mode,
+    balanced_mode,
+    silent_mode,
+    super_battery_mode,
+    unknown_mode
+};
+
+[[nodiscard]] std::optional<user_mode> parseSavedUserMode(const QString &value);
+[[nodiscard]] bool userModeMayOwnAdvanced(user_mode mode);
+
+#endif // MCONTROLCENTER_USER_MODE_POLICY_H

--- a/tests/test_dbus_context.cpp
+++ b/tests/test_dbus_context.cpp
@@ -1,0 +1,335 @@
+#include "../src/helper/authorization.h"
+#include "../src/helper/msi-ec.h"
+#include "../src/helper/service.h"
+
+#include <QCoreApplication>
+#include <QDBusAbstractAdaptor>
+#include <QDBusArgument>
+#include <QDBusConnection>
+#include <QDBusInterface>
+#include <QDBusMessage>
+#include <QDBusReply>
+#include <QDir>
+#include <QElapsedTimer>
+#include <QFile>
+#include <QMap>
+#include <QProcess>
+#include <QTemporaryDir>
+#include <QTest>
+#include <QTextStream>
+#include <QTimer>
+
+namespace {
+const QString testService = QStringLiteral("org.mcontrolcenter.DBusContextTest");
+const QString probeInterface = QStringLiteral("org.mcontrolcenter.DBusContextProbe");
+bool authorizationGranted = true;
+
+FanCurveProfile expectedProfile() {
+    return {{55, 60, 70, 78, 85, 90},
+            {0, 45, 60, 70, 75, 80, 80},
+            {55, 60, 70, 80, 82, 87},
+            {0, 55, 65, 70, 75, 80, 80}};
+}
+
+bool writeSysfsValue(const QString &path, const QString &value) {
+    QFile file(path);
+    const QByteArray data = (value + QLatin1Char('\n')).toUtf8();
+    return file.open(QIODevice::WriteOnly) && file.write(data) == data.size();
+}
+
+bool initializeFakeFanCurveSysfs(const QString &root) {
+    QDir dir(root);
+    if (!dir.mkpath(QStringLiteral("cpu")) || !dir.mkpath(QStringLiteral("gpu")))
+        return false;
+    const QMap<QString, QString> capability{
+        {QStringLiteral("fan_curve_supported"), QStringLiteral("1")},
+        {QStringLiteral("fan_curve_threshold_count"), QStringLiteral("6")},
+        {QStringLiteral("fan_curve_level_count"), QStringLiteral("7")},
+        {QStringLiteral("fan_curve_threshold_min"), QStringLiteral("0")},
+        {QStringLiteral("fan_curve_threshold_max"), QStringLiteral("100")},
+        {QStringLiteral("fan_curve_level_min"), QStringLiteral("0")},
+        {QStringLiteral("fan_curve_level_max"), QStringLiteral("150")},
+        {QStringLiteral("fan_mode"), QStringLiteral("silent")},
+    };
+    for (auto it = capability.cbegin(); it != capability.cend(); ++it) {
+        if (!writeSysfsValue(dir.filePath(it.key()), it.value()))
+            return false;
+    }
+    const FanCurveProfile profile = expectedProfile();
+    const auto writePoints = [&](const QString &fan, const QString &kind,
+                                 const QVector<int> &values) {
+        for (int index = 0; index < values.size(); ++index) {
+            if (!writeSysfsValue(dir.filePath(
+                    QStringLiteral("%1/fan_curve_%2_%3").arg(fan, kind).arg(index + 1)),
+                    QString::number(values[index])))
+                return false;
+        }
+        return true;
+    };
+    return writePoints(QStringLiteral("cpu"), QStringLiteral("threshold"), profile.cpuThresholds) &&
+           writePoints(QStringLiteral("cpu"), QStringLiteral("level"), profile.cpuLevels) &&
+           writePoints(QStringLiteral("gpu"), QStringLiteral("threshold"), profile.gpuThresholds) &&
+           writePoints(QStringLiteral("gpu"), QStringLiteral("level"), profile.gpuLevels);
+}
+
+// This integration target deliberately substitutes a fake authorizer. It
+// grants only when the production adaptor passes the registered object's live
+// D-Bus context with a unique caller name. No PolicyKit service is contacted.
+bool contextHasAuthenticatedCaller(const QDBusContext &context) {
+    return context.calledFromDBus() && context.connection().isConnected() &&
+           context.message().service().startsWith(QLatin1Char(':'));
+}
+
+class ContextProbe final : public QDBusAbstractAdaptor {
+    Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "org.mcontrolcenter.DBusContextProbe")
+public:
+    ContextProbe(DBusContextObject &parent, QString modePath)
+        : QDBusAbstractAdaptor(&parent), context(parent), modePath(std::move(modePath)) {}
+
+public slots:
+    [[nodiscard]] bool hasLiveContext() const {
+        return contextHasAuthenticatedCaller(context.callContext());
+    }
+
+    [[nodiscard]] QString caller() const {
+        const QDBusContext &call = context.callContext();
+        return call.calledFromDBus() ? call.message().service() : QString();
+    }
+
+    [[nodiscard]] QString modeValue() const {
+        QFile file(modePath);
+        return file.open(QIODevice::ReadOnly)
+                   ? QString::fromUtf8(file.readAll()).trimmed()
+                   : QString();
+    }
+
+    bool setAuthorizationGranted(bool granted) const {
+        authorizationGranted = granted;
+        return true;
+    }
+
+    bool quit() const {
+        QTimer::singleShot(0, QCoreApplication::instance(), &QCoreApplication::quit);
+        return true;
+    }
+
+private:
+    DBusContextObject &context;
+    QString modePath;
+};
+
+int runServer(QCoreApplication &app) {
+    QTemporaryDir sysfs;
+    if (!sysfs.isValid())
+        return 70;
+
+    if (!initializeFakeFanCurveSysfs(sysfs.path()))
+        return 71;
+    const QString modePath = sysfs.filePath(QStringLiteral("fan_mode"));
+
+    DBusContextObject probeObject;
+    ContextProbe probe(probeObject, modePath);
+    DBusContextObject msiEcObject;
+    MsiEc msiEc(msiEcObject, sysfs.path());
+
+    QDBusConnection bus = QDBusConnection::sessionBus();
+    if (!bus.isConnected() ||
+        !bus.registerObject(QStringLiteral("/context"), &probeObject) ||
+        !bus.registerObject(QStringLiteral("/msi_ec"), &msiEcObject) ||
+        !bus.registerService(testService)) {
+        return 72;
+    }
+
+    QTextStream(stdout) << "READY\n" << Qt::flush;
+    return app.exec();
+}
+}
+
+// Link-time test double for src/helper/msi-ec.cpp. The production
+// authorization.cpp is intentionally not part of this isolated target.
+bool authorizeHardwareMutation(const QDBusContext &context) {
+    return authorizationGranted && contextHasAuthenticatedCaller(context);
+}
+
+class DBusContextTest final : public QObject {
+    Q_OBJECT
+private slots:
+    void initTestCase();
+    void registeredObjectOwnsCallContext();
+    void invalidArgumentReturnsErrorWithoutCrashing();
+    void authorizationDenialReturnsErrorWithoutWritingOrCrashing();
+    void validCallPassesRegisteredContextToAuthorizer();
+    void fanProfileRoundTripsAcrossPrivateBus();
+    void cleanupTestCase();
+
+private:
+    QProcess server;
+};
+
+void DBusContextTest::initTestCase() {
+    server.setProcessChannelMode(QProcess::MergedChannels);
+    server.start(QCoreApplication::applicationFilePath(), {QStringLiteral("--context-test-server")});
+    QVERIFY2(server.waitForStarted(5000), qPrintable(server.errorString()));
+
+    QByteArray output;
+    QElapsedTimer timer;
+    timer.start();
+    while (!output.contains("READY\n") && timer.elapsed() < 5000) {
+        if (server.waitForReadyRead(250))
+            output += server.readAll();
+        if (server.state() == QProcess::NotRunning)
+            break;
+    }
+    QVERIFY2(output.contains("READY\n"), output.constData());
+}
+
+void DBusContextTest::registeredObjectOwnsCallContext() {
+    QDBusInterface probe(testService, QStringLiteral("/context"), probeInterface,
+                         QDBusConnection::sessionBus());
+    QVERIFY(probe.isValid());
+
+    const QDBusReply<bool> live = probe.call(QStringLiteral("hasLiveContext"));
+    QVERIFY2(live.isValid(), qPrintable(live.error().message()));
+    QVERIFY(live.value());
+
+    const QDBusReply<QString> caller = probe.call(QStringLiteral("caller"));
+    QVERIFY2(caller.isValid(), qPrintable(caller.error().message()));
+    QCOMPARE(caller.value(), QDBusConnection::sessionBus().baseService());
+}
+
+void DBusContextTest::invalidArgumentReturnsErrorWithoutCrashing() {
+    QDBusInterface msiEc(testService, QStringLiteral("/msi_ec"),
+                         QStringLiteral(INTERFACE_NAME_MSI_EC),
+                         QDBusConnection::sessionBus());
+    QVERIFY(msiEc.isValid());
+
+    const QDBusMessage reply = msiEc.call(QStringLiteral("setFanMode"),
+                                          QStringLiteral("not-a-mode"));
+    QCOMPARE(reply.type(), QDBusMessage::ErrorMessage);
+    QCOMPARE(reply.errorName(), QStringLiteral("org.freedesktop.DBus.Error.InvalidArgs"));
+    QVERIFY(server.state() == QProcess::Running);
+
+    QDBusInterface probe(testService, QStringLiteral("/context"), probeInterface,
+                         QDBusConnection::sessionBus());
+    const QDBusReply<bool> stillAlive = probe.call(QStringLiteral("hasLiveContext"));
+    QVERIFY2(stillAlive.isValid(), qPrintable(stillAlive.error().message()));
+    QVERIFY(stillAlive.value());
+}
+
+void DBusContextTest::authorizationDenialReturnsErrorWithoutWritingOrCrashing() {
+    QDBusInterface probe(testService, QStringLiteral("/context"), probeInterface,
+                         QDBusConnection::sessionBus());
+    QDBusReply<bool> configured = probe.call(QStringLiteral("setAuthorizationGranted"), false);
+    QVERIFY2(configured.isValid() && configured.value(), qPrintable(configured.error().message()));
+
+    QDBusInterface msiEc(testService, QStringLiteral("/msi_ec"),
+                         QStringLiteral(INTERFACE_NAME_MSI_EC),
+                         QDBusConnection::sessionBus());
+    const QDBusMessage denied = msiEc.call(QStringLiteral("setFanMode"), QStringLiteral("auto"));
+    QCOMPARE(denied.type(), QDBusMessage::ErrorMessage);
+    QCOMPARE(denied.errorName(), QStringLiteral("org.freedesktop.DBus.Error.AccessDenied"));
+    QVERIFY(server.state() == QProcess::Running);
+
+    const QDBusReply<QString> unchanged = probe.call(QStringLiteral("modeValue"));
+    QVERIFY2(unchanged.isValid(), qPrintable(unchanged.error().message()));
+    QCOMPARE(unchanged.value(), QStringLiteral("silent"));
+
+    configured = probe.call(QStringLiteral("setAuthorizationGranted"), true);
+    QVERIFY2(configured.isValid() && configured.value(), qPrintable(configured.error().message()));
+}
+
+void DBusContextTest::validCallPassesRegisteredContextToAuthorizer() {
+    QDBusInterface msiEc(testService, QStringLiteral("/msi_ec"),
+                         QStringLiteral(INTERFACE_NAME_MSI_EC),
+                         QDBusConnection::sessionBus());
+    const QDBusReply<bool> applied = msiEc.call(QStringLiteral("setFanMode"),
+                                                QStringLiteral("auto"));
+    QVERIFY2(applied.isValid(), qPrintable(applied.error().message()));
+    QVERIFY(applied.value());
+
+    QDBusInterface probe(testService, QStringLiteral("/context"), probeInterface,
+                         QDBusConnection::sessionBus());
+    const QDBusReply<QString> mode = probe.call(QStringLiteral("modeValue"));
+    QVERIFY2(mode.isValid(), qPrintable(mode.error().message()));
+    QCOMPARE(mode.value(), QStringLiteral("auto"));
+}
+
+void DBusContextTest::fanProfileRoundTripsAcrossPrivateBus() {
+    const QVariantMap localProfile = fanCurveProfileToMap(expectedProfile());
+    FanCurveProfile localDecoded;
+    QVERIFY(fanCurveProfileFromMap(localProfile, &localDecoded));
+    QCOMPARE(localDecoded, expectedProfile());
+
+    QDBusInterface msiEc(testService, QStringLiteral("/msi_ec"),
+                         QStringLiteral(INTERFACE_NAME_MSI_EC),
+                         QDBusConnection::sessionBus());
+    QVERIFY(msiEc.isValid());
+
+    const QDBusReply<QVariantMap> profileReply =
+        msiEc.call(QStringLiteral("getFanCurveProfile"));
+    QVERIFY2(profileReply.isValid(), qPrintable(profileReply.error().message()));
+    const QVariantMap wireProfile = profileReply.value();
+    QVERIFY(wireProfile.value(QStringLiteral("readable")).toBool());
+    QVERIFY(wireProfile.value(QStringLiteral("valid")).toBool());
+    for (const QString &key : {QStringLiteral("cpu_thresholds"),
+                               QStringLiteral("cpu_levels"),
+                               QStringLiteral("gpu_thresholds"),
+                               QStringLiteral("gpu_levels")}) {
+        const QVariant value = wireProfile.value(key);
+        QVERIFY(value.metaType() == QMetaType::fromType<QDBusArgument>() ||
+                value.canConvert<QVariantList>());
+        if (value.metaType() == QMetaType::fromType<QDBusArgument>())
+            QCOMPARE(qvariant_cast<QDBusArgument>(value).currentSignature(), QStringLiteral("av"));
+    }
+
+    FanCurveProfile decoded;
+    QVERIFY(fanCurveProfileFromMap(wireProfile, &decoded));
+    QCOMPARE(decoded, expectedProfile());
+
+    const QDBusReply<QVariantMap> applyReply =
+        msiEc.call(QStringLiteral("applyFanCurveTransaction"), fanCurveProfileToMap(decoded));
+    QVERIFY2(applyReply.isValid(), qPrintable(applyReply.error().message()));
+    const FanCurveResult result = fanCurveResultFromMap(applyReply.value());
+    QVERIFY2(result.success, qPrintable(result.error));
+    QCOMPARE(result.effectiveMode, QStringLiteral("advanced"));
+    QCOMPARE(result.rollbackStatus, QStringLiteral("not-needed"));
+
+    const QDBusReply<QVariantMap> readbackReply =
+        msiEc.call(QStringLiteral("getFanCurveProfile"));
+    QVERIFY2(readbackReply.isValid(), qPrintable(readbackReply.error().message()));
+    FanCurveProfile readback;
+    QVERIFY(fanCurveProfileFromMap(readbackReply.value(), &readback));
+    QCOMPARE(readback, expectedProfile());
+
+    const QDBusReply<bool> restored =
+        msiEc.call(QStringLiteral("setFanMode"), QStringLiteral("auto"));
+    QVERIFY2(restored.isValid(), qPrintable(restored.error().message()));
+    QVERIFY(restored.value());
+}
+
+void DBusContextTest::cleanupTestCase() {
+    if (server.state() == QProcess::NotRunning)
+        return;
+    QDBusInterface probe(testService, QStringLiteral("/context"), probeInterface,
+                         QDBusConnection::sessionBus());
+    const QDBusReply<bool> stopped = probe.call(QStringLiteral("quit"));
+    QVERIFY2(stopped.isValid() && stopped.value(), qPrintable(stopped.error().message()));
+    if (!server.waitForFinished(3000)) {
+        server.terminate();
+        QVERIFY(server.waitForFinished(3000));
+    }
+    QCOMPARE(server.exitStatus(), QProcess::NormalExit);
+    QCOMPARE(server.exitCode(), 0);
+}
+
+int main(int argc, char **argv) {
+    QCoreApplication app(argc, argv);
+    if (app.arguments().contains(QStringLiteral("--context-test-server")))
+        return runServer(app);
+
+    DBusContextTest test;
+    return QTest::qExec(&test, argc, argv);
+}
+
+#include "test_dbus_context.moc"

--- a/tests/test_fan_curve.cpp
+++ b/tests/test_fan_curve.cpp
@@ -1,0 +1,327 @@
+#include "../src/fan_curve.h"
+#include "../src/helper/fan-curve.h"
+#include "../src/helper/authorization.h"
+#include "../src/settings.h"
+#include "../src/user_mode_policy.h"
+
+#include <QtTest/QtTest>
+#include <QDir>
+#include <QFile>
+#include <QStringList>
+#include <QTemporaryDir>
+
+class FakeBackend final : public FanCurveBackend {
+public:
+    FanCurveCapability cap{true, 6, 7, 0, 100, 0, 150, {}};
+    FanCurveProfile profile{{10, 20, 30, 40, 50, 60}, {0, 20, 40, 60, 80, 100, 120},
+                            {10, 20, 30, 40, 50, 60}, {0, 20, 40, 60, 80, 100, 120}};
+    QString mode = QStringLiteral("advanced");
+    int pointWrites = 0;
+    int failPointWrite = -1;
+    bool failPointAlways = false;
+    bool failAdvanced = false;
+    bool ignoreModeWrites = false;
+
+    [[nodiscard]] FanCurveCapability capability() const override { return cap; }
+    [[nodiscard]] bool readProfile(FanCurveProfile *result, QString *) const override {
+        if (!result)
+            return false;
+        *result = profile;
+        return true;
+    }
+    [[nodiscard]] QString readMode() const override { return mode; }
+    bool writeMode(const QString &newMode, QString *error) override {
+        if (newMode == QStringLiteral("advanced") && failAdvanced) {
+            if (error)
+                *error = QStringLiteral("injected activation failure");
+            return false;
+        }
+        if (newMode != QStringLiteral("auto") && newMode != QStringLiteral("silent") &&
+            newMode != QStringLiteral("basic") && newMode != QStringLiteral("advanced"))
+            return false;
+        if (!ignoreModeWrites)
+            mode = newMode;
+        return true;
+    }
+    bool writePoint(const QString &fan, const QString &kind, int index,
+                    int value, QString *error) override {
+        ++pointWrites;
+        if (failPointWrite > 0 && pointWrites >= failPointWrite &&
+            (failPointAlways || pointWrites == failPointWrite)) {
+            if (error)
+                *error = QStringLiteral("injected point failure");
+            return false;
+        }
+        QVector<int> *values = nullptr;
+        if (fan == QStringLiteral("cpu") && kind == QStringLiteral("threshold"))
+            values = &profile.cpuThresholds;
+        else if (fan == QStringLiteral("cpu") && kind == QStringLiteral("level"))
+            values = &profile.cpuLevels;
+        else if (fan == QStringLiteral("gpu") && kind == QStringLiteral("threshold"))
+            values = &profile.gpuThresholds;
+        else if (fan == QStringLiteral("gpu") && kind == QStringLiteral("level"))
+            values = &profile.gpuLevels;
+        if (!values || index < 1 || index > values->size())
+            return false;
+        (*values)[index - 1] = value;
+        return true;
+    }
+};
+
+static FanCurveProfile requestedProfile() {
+    return {{15, 25, 35, 45, 55, 65}, {10, 20, 20, 40, 80, 100, 140},
+            {15, 25, 35, 45, 55, 65}, {10, 20, 20, 40, 80, 100, 140}};
+}
+
+class FanCurveTest : public QObject {
+    Q_OBJECT
+private slots:
+    void validatorBoundaries();
+    void ignoredFanModeWriteReadbackMismatch();
+    void readableMalformedDeviceCurveIsRepairable();
+    void sysfsMalformedBaselineIsReadable();
+    void capabilityAbsence();
+    void successfulTransaction();
+    void midWriteRollback();
+    void rollbackFailureForcesAuto();
+    void silentRollback();
+    void activationFailureSafety();
+    void malformedAdvancedRollbackStaysAuto();
+    void firmwareMismatch();
+    void malformedSettings();
+    void savedUserModeParsing();
+    void advancedModeOwnershipPolicy();
+    void policyKitAuthorizationContract();
+    void authorizationDeniesNonDbusCalls();
+    void telemetryUnitContract();
+};
+
+void FanCurveTest::ignoredFanModeWriteReadbackMismatch() {
+    FakeBackend backend;
+    backend.ignoreModeWrites = true;
+    QString error;
+    QVERIFY(!writeFanModeVerified(backend, QStringLiteral("auto"), &error));
+    QVERIFY(error.contains(QStringLiteral("readback")));
+}
+
+void FanCurveTest::validatorBoundaries() {
+    FakeBackend backend;
+    QVERIFY(validateFanCurve(backend.cap, requestedProfile()).isEmpty());
+    FanCurveProfile invalid = requestedProfile();
+    invalid.cpuThresholds[0] = -1;
+    QVERIFY(!validateFanCurve(backend.cap, invalid).isEmpty());
+    invalid = requestedProfile();
+    invalid.cpuThresholds[1] = invalid.cpuThresholds[0];
+    QVERIFY(!validateFanCurve(backend.cap, invalid).isEmpty());
+    invalid = requestedProfile();
+    invalid.cpuLevels[2] = invalid.cpuLevels[1] - 1;
+    QVERIFY(!validateFanCurve(backend.cap, invalid).isEmpty());
+}
+
+void FanCurveTest::readableMalformedDeviceCurveIsRepairable() {
+    FakeBackend backend;
+    FanCurveProfile device = requestedProfile();
+    device.cpuThresholds = {55, 65, 0, 0, 0, 0};
+    device.cpuLevels[6] = 200;
+    QVERIFY(!fanCurveProfileWithinRanges(backend.cap, device).isEmpty());
+    QVERIFY(!validateFanCurve(backend.cap, device).isEmpty());
+}
+
+void FanCurveTest::sysfsMalformedBaselineIsReadable() {
+    QTemporaryDir root;
+    QVERIFY(root.isValid());
+    const auto write = [](const QString &path, const QString &value) {
+        QFile file(path);
+        QVERIFY2(file.open(QIODevice::WriteOnly), qPrintable(path));
+        QVERIFY(file.write(value.toUtf8()) == value.toUtf8().size());
+    };
+    write(root.filePath("fan_curve_supported"), "1\n");
+    write(root.filePath("fan_curve_threshold_count"), "6\n");
+    write(root.filePath("fan_curve_level_count"), "7\n");
+    write(root.filePath("fan_curve_threshold_min"), "0\n");
+    write(root.filePath("fan_curve_threshold_max"), "100\n");
+    write(root.filePath("fan_curve_level_min"), "0\n");
+    write(root.filePath("fan_curve_level_max"), "150\n");
+    write(root.filePath("fan_mode"), "auto\n");
+    QDir().mkpath(root.filePath("cpu"));
+    QDir().mkpath(root.filePath("gpu"));
+    const QVector<int> thresholds = {55, 65, 0, 0, 0, 0};
+    const QVector<int> levels = {0, 20, 40, 60, 80, 100, 200};
+    for (const QString &fan : {QStringLiteral("cpu"), QStringLiteral("gpu")}) {
+        for (int i = 0; i < thresholds.size(); ++i)
+            write(root.filePath(fan + QStringLiteral("/fan_curve_threshold_") + QString::number(i + 1)),
+                  QString::number(thresholds[i]) + QLatin1Char('\n'));
+        for (int i = 0; i < levels.size(); ++i)
+            write(root.filePath(fan + QStringLiteral("/fan_curve_level_") + QString::number(i + 1)),
+                  QString::number(levels[i]) + QLatin1Char('\n'));
+    }
+    SysfsFanCurveBackend backend(root.path());
+    QVERIFY(backend.capability().complete());
+    FanCurveProfile profile;
+    QString error;
+    QVERIFY(backend.readProfile(&profile, &error));
+    QVERIFY(!fanCurveProfileWithinRanges(backend.capability(), profile).isEmpty());
+    QVERIFY(!validateFanCurve(backend.capability(), profile).isEmpty());
+    QVERIFY(QFile::remove(root.filePath("gpu/fan_curve_level_7")));
+    QVERIFY(!backend.capability().complete());
+}
+
+void FanCurveTest::capabilityAbsence() {
+    FakeBackend backend;
+    backend.cap.supported = false;
+    FanCurveTransaction transaction(backend);
+    const FanCurveResult result = transaction.apply(requestedProfile());
+    QVERIFY(!result.success);
+    QCOMPARE(backend.pointWrites, 0);
+}
+
+void FanCurveTest::successfulTransaction() {
+    FakeBackend backend;
+    backend.mode = QStringLiteral("silent");
+    FanCurveTransaction transaction(backend);
+    const FanCurveResult result = transaction.apply(requestedProfile());
+    QVERIFY(result.success);
+    QCOMPARE(result.effectiveMode, QStringLiteral("advanced"));
+    QCOMPARE(backend.mode, QStringLiteral("advanced"));
+    QCOMPARE(backend.profile, requestedProfile());
+}
+
+void FanCurveTest::midWriteRollback() {
+    FakeBackend backend;
+    backend.mode = QStringLiteral("auto");
+    backend.failPointWrite = 4;
+    FanCurveTransaction transaction(backend);
+    const FanCurveProfile snapshot = backend.profile;
+    const FanCurveResult result = transaction.apply(requestedProfile());
+    QVERIFY(!result.success);
+    QCOMPARE(result.rollbackStatus, QStringLiteral("succeeded"));
+    QCOMPARE(result.effectiveMode, QStringLiteral("auto"));
+    QCOMPARE(backend.profile, snapshot);
+}
+
+void FanCurveTest::rollbackFailureForcesAuto() {
+    FakeBackend backend;
+    backend.mode = QStringLiteral("silent");
+    backend.failPointWrite = 1;
+    backend.failPointAlways = true;
+    FanCurveTransaction transaction(backend);
+    const FanCurveResult result = transaction.apply(requestedProfile());
+    QVERIFY(!result.success);
+    QCOMPARE(result.rollbackStatus, QStringLiteral("failed_auto"));
+    QCOMPARE(result.effectiveMode, QStringLiteral("auto"));
+    QCOMPARE(backend.mode, QStringLiteral("auto"));
+}
+
+void FanCurveTest::silentRollback() {
+    FakeBackend backend;
+    backend.mode = QStringLiteral("silent");
+    backend.failPointWrite = 5;
+    FanCurveTransaction transaction(backend);
+    const FanCurveResult result = transaction.apply(requestedProfile());
+    QVERIFY(!result.success);
+    QCOMPARE(result.rollbackStatus, QStringLiteral("succeeded"));
+    QCOMPARE(result.effectiveMode, QStringLiteral("silent"));
+    QCOMPARE(backend.mode, QStringLiteral("silent"));
+}
+
+void FanCurveTest::malformedAdvancedRollbackStaysAuto() {
+    FakeBackend backend;
+    backend.mode = QStringLiteral("advanced");
+    backend.profile.cpuThresholds = {55, 65, 0, 0, 0, 0};
+    backend.failPointWrite = 4;
+    FanCurveTransaction transaction(backend);
+    const FanCurveResult result = transaction.apply(requestedProfile());
+    QVERIFY(!result.success);
+    QCOMPARE(result.rollbackStatus, QStringLiteral("succeeded"));
+    QCOMPARE(result.effectiveMode, QStringLiteral("auto"));
+    QCOMPARE(backend.mode, QStringLiteral("auto"));
+}
+
+void FanCurveTest::activationFailureSafety() {
+    FakeBackend backend;
+    backend.mode = QStringLiteral("silent");
+    backend.failAdvanced = true;
+    FanCurveTransaction transaction(backend);
+    const FanCurveResult result = transaction.apply(requestedProfile());
+    QVERIFY(!result.success);
+    QCOMPARE(result.rollbackStatus, QStringLiteral("succeeded"));
+    QCOMPARE(result.effectiveMode, QStringLiteral("silent"));
+    QCOMPARE(backend.mode, QStringLiteral("silent"));
+}
+
+void FanCurveTest::firmwareMismatch() {
+    QVERIFY(fanCurveFirmwareMatches(QStringLiteral("15CKEMS1.108"), QStringLiteral("2026-01-01"),
+                                     QStringLiteral("15CKEMS1.108"), QStringLiteral("2026-01-01")));
+    QVERIFY(!fanCurveFirmwareMatches(QStringLiteral("15CKEMS1.108"), QStringLiteral("2026-01-01"),
+                                     QStringLiteral("15CKEMS1.109"), QStringLiteral("2026-01-01")));
+    QVERIFY(!fanCurveFirmwareMatches({}, {}, QStringLiteral("15CKEMS1.108"), QStringLiteral("2026-01-01")));
+}
+
+void FanCurveTest::telemetryUnitContract() {
+    QFile source(QStringLiteral(FAN_SOURCE_DIR "/src/mainwindow.cpp"));
+    QVERIFY(source.open(QIODevice::ReadOnly));
+    const QString text = QString::fromUtf8(source.readAll());
+    QVERIFY2(!text.contains(QStringLiteral("getCPURealtimeFanSpeed")),
+             "driver fan-level telemetry must not be displayed as RPM");
+    QVERIFY2(!text.contains(QStringLiteral("getGPURealtimeFanSpeed")),
+             "driver fan-level telemetry must not be displayed as RPM");
+}
+
+void FanCurveTest::policyKitAuthorizationContract() {
+    const QStringList interactiveArgs = policyKitArgumentsForBusName(QStringLiteral(":1.42"), true);
+    QCOMPARE(interactiveArgs, QStringList({QStringLiteral("--action-id"),
+                                            QStringLiteral("org.mcontrolcenter.fan-control"),
+                                            QStringLiteral("--system-bus-name"), QStringLiteral(":1.42"),
+                                            QStringLiteral("--allow-user-interaction")}));
+    const QStringList helperArgs = policyKitArgumentsForBusName(QStringLiteral(":1.42"), false);
+    QCOMPARE(helperArgs, QStringList({QStringLiteral("--action-id"),
+                                      QStringLiteral("org.mcontrolcenter.fan-control"),
+                                      QStringLiteral("--system-bus-name"), QStringLiteral(":1.42")}));
+    QVERIFY(!helperArgs.contains(QStringLiteral("--allow-user-interaction")));
+    QCOMPARE(FAN_AUTHORIZATION_TIMEOUT_MS, 60000);
+    QCOMPARE(FAN_HELPER_AUTHORIZATION_TIMEOUT_MS, 3000);
+    QVERIFY(FAN_DBUS_TIMEOUT_MS > FAN_HELPER_AUTHORIZATION_TIMEOUT_MS);
+}
+
+void FanCurveTest::authorizationDeniesNonDbusCalls() {
+    QDBusContext context;
+    QVERIFY(!context.calledFromDBus());
+    QVERIFY(!authorizeHardwareMutation(context));
+}
+
+void FanCurveTest::malformedSettings() {
+    bool ok = true;
+    QVERIFY(Settings::parseValueVector(QStringLiteral("10|bad|30"), &ok).isEmpty());
+    QVERIFY(!ok);
+    ok = false;
+    QCOMPARE(Settings::parseValueVector(QStringLiteral("10|20|30"), &ok), QVector<int>({10, 20, 30}));
+    QVERIFY(ok);
+}
+
+void FanCurveTest::savedUserModeParsing() {
+    const auto verifyMode = [](const QString &value, user_mode expected) {
+        const auto parsed = parseSavedUserMode(value);
+        QVERIFY(parsed.has_value());
+        QCOMPARE(static_cast<int>(*parsed), static_cast<int>(expected));
+    };
+    verifyMode(QStringLiteral("balanced_mode"), user_mode::balanced_mode);
+    verifyMode(QStringLiteral("performance_mode"), user_mode::performance_mode);
+    verifyMode(QStringLiteral("silent_mode"), user_mode::silent_mode);
+    verifyMode(QStringLiteral("super_battery_mode"), user_mode::super_battery_mode);
+
+    for (const QString &invalid : {QString(), QStringLiteral("unknown_mode"),
+                                   QStringLiteral("advanced"), QStringLiteral(" balanced_mode"),
+                                   QStringLiteral("Balanced_mode")})
+        QVERIFY(!parseSavedUserMode(invalid).has_value());
+}
+
+void FanCurveTest::advancedModeOwnershipPolicy() {
+    QVERIFY(userModeMayOwnAdvanced(user_mode::balanced_mode));
+    QVERIFY(userModeMayOwnAdvanced(user_mode::performance_mode));
+    QVERIFY(!userModeMayOwnAdvanced(user_mode::silent_mode));
+    QVERIFY(!userModeMayOwnAdvanced(user_mode::super_battery_mode));
+    QVERIFY(!userModeMayOwnAdvanced(user_mode::unknown_mode));
+}
+
+QTEST_MAIN(FanCurveTest)
+#include "test_fan_curve.moc"


### PR DESCRIPTION
## Summary

- move fan-curve and mode control onto the typed `msi-ec` ABI and keep legacy `ec_sys`/`acpi_ec` access read-only for optional RPM diagnostics
- add strict capability/profile validation plus a transactional 26-point apply flow with exact readback, rollback, verified Auto fallback, and firmware-bound persistence
- add a PolicyKit action and bind authorization to the QObject actually registered on D-Bus, failing closed when there is no authenticated call context
- decode both local `QVariantList` values and real Qt D-Bus `QDBusArgument` arrays (`av`) at the shared profile boundary
- reconcile verified fan preferences across user-mode changes and logind resume while preserving current PowerMonitor/automatic-profile behavior
- install/uninstall the PolicyKit policy and document the fan-control contract

## Safety properties

- generic raw EC write methods are removed; fan mutations use only named typed `msi-ec` sysfs nodes
- editing is disabled unless the complete 6-threshold/7-level CPU+GPU ABI is present
- profiles require exact counts, bounded values, strictly increasing thresholds, and nondecreasing fan levels
- every point and mode transition is read back; any anomaly rolls back, and an unprovable state is forced to verified Auto
- malformed Advanced snapshots are never reactivated
- helper authorization rejects non-D-Bus calls, empty senders, disconnected contexts, and PolicyKit failure/timeout
- GUI refresh uses signal blockers; Power Profiles Daemon transitions invoke each verified setter only once

See `docs/fan_curve.md` for the complete contract.

## Tests

Validated on Fedora 44 / Qt 6.11:

- full application and helper build: pass
- `fan-curve-tests`: 20 passed
- private-bus `dbus-context-tests`: 7 passed
- private-bus suite repeated 100 times: pass
- XML validation, shell syntax, conflict-marker scan, and `git diff --check`: pass
- independent security/correctness review: approved after fixing a PowerMonitor re-entry path found during review

The underlying feature line was also packaged and installed locally on MSI hardware with the required typed driver ABI:

- real system-bus profile fields arrived as `QDBusArgument av` and all 26 values decoded correctly
- an exact same-profile transaction reached verified Advanced, read back all 26 points, then restored Auto with byte-identical protected state
- isolated and normal-profile GUI startup passed with captured helper-call auditing
- one RTC-timed `s2idle` cycle passed; the GUI survived and wake replay was exactly the saved mode restoration
- no new helper coredump, unsafe temperature, settings loss, or final hardware-state change

The current-`main` integration in this PR was rebuilt and reran the complete automated suite; it was not installed over the locally validated package.

## Driver compatibility

Systems without the complete typed fan-curve ABI remain supported: fan-curve editing is disabled with an explanatory status, while other typed `msi-ec` features continue to work. Raw EC write support is neither required nor enabled.
